### PR TITLE
Add check-model-name-contract hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -81,6 +81,12 @@
     entry: check-model-has-tests
     language: python
     types: [sql]
+-   id: check-model-name-contract
+    name: Check model name contract
+    description: Check model name abides to contract.
+    entry: check-model-name-contract
+    language: python
+    types: [sql]
 -   id: check-model-parents-and-childs
     name: Check the model has a parents/childs
     description: Ensures the model has a specific number (max/min) of parents or/and childs.

--- a/HOOKS.md
+++ b/HOOKS.md
@@ -2,9 +2,11 @@
 
 :bulb: Click on hook name to view the details.
 
+[`check-column-name-contract`]: https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-column-name-contract
+
 **Model checks:**
  * [`check-column-desc-are-same`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-column-desc-are-same): Check column descriptions are the same.
- * [`check-column-name-contract`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-column-name-contract): Check column name abides to contract.
+ * [`check-column-name-contract`](): Check column name abides to contract.
  * [`check-model-columns-have-desc`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-model-columns-have-desc): Check the model columns have description.
  * [`check-model-has-all-columns`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-model-has-all-columns): Check the model has all columns in the properties file.
  * [`check-model-has-description`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-model-has-description): Check the model has description.
@@ -14,6 +16,7 @@
  * [`check-model-has-tests-by-type`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-model-has-tests-by-type): Check the model has a number of tests by test type.
  * [`check-model-has-tests-by-group`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-model-has-tests-by-group): Check the model has a number of tests from a group of tests.
  * [`check-model-has-tests`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-model-has-tests): Check the model has a number of tests.
+ * [`check-model-name-contract`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-model-name-contract): Check model name abides to contract.
  * [`check-model-parents-and-childs`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-model-parents-and-childs): Check the model has a specific number (max/min) of parents or/and childs.
  * [`check-model-parents-database`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-model-parents-database): Check the parent model has a specific database.
  * [`check-model-parents-schema`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-model-parents-schema): Check the parent model has a specific schema.
@@ -532,6 +535,49 @@ You want to make sure that every model was tested.
 
 -----
 
+### `check-model-name-contract`
+
+Check that model name abides to a contract (similar to [`check-column-name-contract`]()). A contract consists of a regex pattern.
+
+#### Arguments
+
+`--pattern`: Regex pattern to match model names.
+
+#### Example
+```
+repos:
+- repo: https://github.com/offbi/pre-commit-dbt
+ rev: v1.0.0
+ hooks:
+ - id: check-model-name-contract
+   args: [--pattern, "(base_|stg_).*"]
+   files: models/staging/
+ - id: check-model-name-contract
+   args: [--pattern, "(dim_|fct_).*"]
+   files: models/marts/
+```
+
+#### When to use it
+
+You want to make sure your model names follow a naming convention (e.g., staging models start with a `stg_` prefix).
+
+#### Requirements
+
+| Model exists in `manifest.json` <sup id="a1">[1](#f1)</sup> | Model exists in `catalog.json` <sup id="a2">[2](#f2)</sup> |
+| :----: | :----------: |
+| :x: Not needed | :white_check_mark: Yes |
+
+<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
+
+#### How it works
+
+- Hook takes all changed `SQL` files.
+- The model name is obtained from the `SQL` file name.
+- The catalog is scanned for a model.
+- If any model does not match the regex pattern, the hook fails.
+
+-----
 ### `check-model-parents-and-childs`
 
 Ensures the model has a specific number (max/min) of parents or/and childs.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ If this is the case, `pre-commit-dbt` is here to help you!
  * [`check-model-has-tests-by-type`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-model-has-tests-by-type): Check the model has a number of tests by test type.
  * [`check-model-has-tests-by-group`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-model-has-tests-by-group): Check the model has a number of tests from a group of tests.
  * [`check-model-has-tests`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-model-has-tests): Check the model has a number of tests.
+ * [`check-model-name-contract`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-model-name-contract): Check model name abides to contract.
  * [`check-model-parents-and-childs`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-model-parents-and-childs): Check the model has a specific number (max/min) of parents or/and childs.
  * [`check-model-parents-database`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-model-parents-database): Check the parent model has a specific database.
  * [`check-model-parents-schema`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-model-parents-schema): Check the parent model has a specific schema.

--- a/pre_commit_dbt/check_model_name_contract.py
+++ b/pre_commit_dbt/check_model_name_contract.py
@@ -1,0 +1,84 @@
+import argparse
+import re
+from typing import Any
+from typing import Dict
+from typing import Optional
+from typing import Sequence
+
+from pre_commit_dbt.utils import add_catalog_args
+from pre_commit_dbt.utils import add_filenames_args
+from pre_commit_dbt.utils import get_filenames
+from pre_commit_dbt.utils import get_json
+from pre_commit_dbt.utils import get_models
+from pre_commit_dbt.utils import JsonOpenError
+
+
+def check_model_name_contract(
+    paths: Sequence[str], pattern: str, dtype: str, catalog: Dict[str, Any]
+) -> int:
+    status_code = 0
+    sqls = get_filenames(paths, [".sql"])
+    filenames = set(sqls.keys())
+    models = get_models(catalog, filenames)
+
+    for model in models:
+        for col in model.node.get("columns", []).values():
+            col_name = col.get("name")
+            col_type = col.get("type")
+
+            # Check all files of type dtype follow naming pattern
+            if dtype == col_type:
+                if re.match(pattern, col_name) is None:
+                    status_code = 1
+                    print(
+                        f"{col_name}: column is of type {dtype} and "
+                        f"does not match regex pattern {pattern}."
+                    )
+
+            # Check all files with naming pattern are of type dtype
+            elif re.match(pattern, col_name):
+                status_code = 1
+                print(
+                    f"{col_name}: column name matches regex pattern {pattern} "
+                    f"and is of type {col_type} instead of {dtype}."
+                )
+
+    return status_code
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser()
+    add_filenames_args(parser)
+    add_catalog_args(parser)
+
+    parser.add_argument(
+        "--pattern",
+        type=str,
+        required=True,
+        help="Regex pattern to match column names.",
+    )
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        required=True,
+        help="Expected data type for the matching columns.",
+    )
+
+    args = parser.parse_args(argv)
+
+    try:
+        catalog = get_json(args.catalog)
+    except JsonOpenError as e:
+        print(f"Unable to load catalog file ({e})")
+        return 1
+
+    return check_model_name_contract(
+        paths=args.filenames,
+        pattern=args.pattern,
+        dtype=args.dtype,
+        catalog=catalog,
+    )
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ console_scripts =
     check-model-has-tests-by-type = pre_commit_dbt.check_model_has_tests_by_type:main
     check-model-has-tests-by-group = pre_commit_dbt.check_model_has_tests_by_group:main
     check-model-has-tests = pre_commit_dbt.check_model_has_tests:main
+    check-model-name-contract = pre_commit_dbt.check_model_name_contract:main
     check-model-parents-and-childs = pre_commit_dbt.check_model_parents_and_childs:main
     check-model-parents-database = pre_commit_dbt.check_model_parents_database:main
     check-model-parents-schema = pre_commit_dbt.check_model_parents_schema:main

--- a/tests/unit/test_check_model_name_contract.py
+++ b/tests/unit/test_check_model_name_contract.py
@@ -1,0 +1,28 @@
+import pytest
+
+from pre_commit_dbt.check_model_name_contract import main
+
+
+# Input args, valid manifest, expected return value
+TESTS = (
+    (["aa/bb/catalog_cols.sql"], "catalog_.*", True, 0),
+    (["aa/bb/catalog_cols.sql"], "catalog_.*", False, 1),
+    (["aa/bb/catalog_cols.sql"], ".*_cols", True, 0),
+    (["aa/bb/catalog_cols.sql"], ".*_col", True, 0),
+    (["aa/bb/catalog_cols.sql"], ".*_col$", True, 1),
+    (["aa/bb/catalog_cols.sql"], "catalog_cols", True, 0),
+    (["aa/bb/catalog_cols.sql"], "cat_.*", True, 1),
+)
+
+
+@pytest.mark.parametrize(
+    ("input_args", "pattern", "valid_catalog", "expected_status_code"), TESTS
+)
+def test_model_name_contract(
+    input_args, pattern, valid_catalog, expected_status_code, catalog_path_str
+):
+    if valid_catalog:
+        input_args.extend(["--catalog", catalog_path_str])
+    input_args.extend(["--pattern", pattern])
+    status_code = main(input_args)
+    assert status_code == expected_status_code


### PR DESCRIPTION
There's now a `check-model-name-contract` hook (similar to `check-model-name-contract`) that is used to ensure that models follow naming convention.

## To-do before merge

- [x] Write unit tests for the hook