### PR TITLE
add prj_root argument to dbt commands

### DIFF
--- a/pre_commit_dbt/dbt_clean.py
+++ b/pre_commit_dbt/dbt_clean.py
@@ -1,7 +1,9 @@
+import argparse
 from typing import List
 from typing import Optional
 from typing import Sequence
 
+from pre_commit_dbt.utils import add_dbt_cmd_prj_root
 from pre_commit_dbt.utils import run_dbt_cmd
 
 
@@ -11,8 +13,12 @@ def prepare_cmd() -> List[str]:
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser()    
+    add_dbt_cmd_prj_root(parser)
+
+    args = parser.parse_args(argv)
     cmd = prepare_cmd()
-    return run_dbt_cmd(cmd)
+    return run_dbt_cmd(cmd, prj_root=args.prj_root)
 
 
 if __name__ == "__main__":

--- a/pre_commit_dbt/dbt_compile.py
+++ b/pre_commit_dbt/dbt_compile.py
@@ -5,6 +5,7 @@ from typing import Sequence
 
 from pre_commit_dbt.utils import add_dbt_cmd_args
 from pre_commit_dbt.utils import add_dbt_cmd_model_args
+from pre_commit_dbt.utils import add_dbt_cmd_prj_root
 from pre_commit_dbt.utils import add_filenames_args
 from pre_commit_dbt.utils import get_flags
 from pre_commit_dbt.utils import paths_to_dbt_models
@@ -34,6 +35,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     add_filenames_args(parser)
     add_dbt_cmd_args(parser)
     add_dbt_cmd_model_args(parser)
+    add_dbt_cmd_prj_root(parser)
 
     args = parser.parse_args(argv)
 
@@ -45,7 +47,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         args.model_postfix,
         args.models,
     )
-    return run_dbt_cmd(cmd)
+    return run_dbt_cmd(cmd, prj_root=args.prj_root)
 
 
 if __name__ == "__main__":

--- a/pre_commit_dbt/dbt_deps.py
+++ b/pre_commit_dbt/dbt_deps.py
@@ -1,7 +1,9 @@
+import argparse
 from typing import List
 from typing import Optional
 from typing import Sequence
 
+from pre_commit_dbt.utils import add_dbt_cmd_prj_root
 from pre_commit_dbt.utils import run_dbt_cmd
 
 
@@ -11,8 +13,13 @@ def prepare_cmd() -> List[str]:
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser()    
+    add_dbt_cmd_prj_root(parser)
+
+    args = parser.parse_args(argv)
+
     cmd = prepare_cmd()
-    return run_dbt_cmd(cmd)
+    return run_dbt_cmd(cmd, prj_root=args.prj_root)
 
 
 if __name__ == "__main__":

--- a/pre_commit_dbt/dbt_docs_generate.py
+++ b/pre_commit_dbt/dbt_docs_generate.py
@@ -4,6 +4,7 @@ from typing import Optional
 from typing import Sequence
 
 from pre_commit_dbt.utils import add_dbt_cmd_args
+from pre_commit_dbt.utils import add_dbt_cmd_prj_root
 from pre_commit_dbt.utils import get_flags
 from pre_commit_dbt.utils import run_dbt_cmd
 
@@ -21,11 +22,12 @@ def docs_generate_cmd(
 def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser()
     add_dbt_cmd_args(parser)
+    add_dbt_cmd_prj_root(parser)
 
     args = parser.parse_args(argv)
 
     cmd = docs_generate_cmd(args.global_flags, args.cmd_flags)
-    return run_dbt_cmd(cmd)
+    return run_dbt_cmd(cmd, prj_root=args.prj_root)
 
 
 if __name__ == "__main__":

--- a/pre_commit_dbt/dbt_run.py
+++ b/pre_commit_dbt/dbt_run.py
@@ -5,6 +5,7 @@ from typing import Sequence
 
 from pre_commit_dbt.utils import add_dbt_cmd_args
 from pre_commit_dbt.utils import add_dbt_cmd_model_args
+from pre_commit_dbt.utils import add_dbt_cmd_prj_root
 from pre_commit_dbt.utils import add_filenames_args
 from pre_commit_dbt.utils import get_flags
 from pre_commit_dbt.utils import paths_to_dbt_models
@@ -34,6 +35,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     add_filenames_args(parser)
     add_dbt_cmd_args(parser)
     add_dbt_cmd_model_args(parser)
+    add_dbt_cmd_prj_root(parser)
 
     args = parser.parse_args(argv)
 
@@ -45,7 +47,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         args.model_postfix,
         args.models,
     )
-    return run_dbt_cmd(cmd)
+    return run_dbt_cmd(cmd, prj_root=args.prj_root)
 
 
 if __name__ == "__main__":

--- a/pre_commit_dbt/dbt_test.py
+++ b/pre_commit_dbt/dbt_test.py
@@ -5,6 +5,7 @@ from typing import Sequence
 
 from pre_commit_dbt.utils import add_dbt_cmd_args
 from pre_commit_dbt.utils import add_dbt_cmd_model_args
+from pre_commit_dbt.utils import add_dbt_cmd_prj_root
 from pre_commit_dbt.utils import add_filenames_args
 from pre_commit_dbt.utils import get_flags
 from pre_commit_dbt.utils import paths_to_dbt_models
@@ -34,6 +35,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     add_filenames_args(parser)
     add_dbt_cmd_args(parser)
     add_dbt_cmd_model_args(parser)
+    add_dbt_cmd_prj_root(parser)
 
     args = parser.parse_args(argv)
 
@@ -45,7 +47,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         args.model_postfix,
         args.models,
     )
-    return run_dbt_cmd(cmd)
+    return run_dbt_cmd(cmd, prj_root=args.prj_root)
 
 
 if __name__ == "__main__":

--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -89,11 +89,12 @@ class SourceSchema:
 def cmd_output(
     *cmd: str,
     expected_code: Optional[int] = 0,
+    prj_root: Optional[str] = None,
     **kwargs: Any,
 ) -> str:
     kwargs.setdefault("stdout", subprocess.PIPE)
     kwargs.setdefault("stderr", subprocess.PIPE)
-    proc = subprocess.Popen(cmd, **kwargs)
+    proc = subprocess.Popen(cmd, **kwargs, cwd=prj_root)
     stdout, stderr = proc.communicate()
     stdout = stdout.decode()
     if expected_code is not None and proc.returncode != expected_code:
@@ -291,11 +292,11 @@ def get_filenames(
     return result
 
 
-def run_dbt_cmd(cmd: Sequence[Any]) -> int:
+def run_dbt_cmd(cmd: Sequence[Any], prj_root: Optional[str] = None) -> int:
     status_code = 0
     print(f"Executing cmd: `{' '.join(cmd)}`")
     try:
-        output = cmd_output(*list(filter(None, cmd)), expected_code=0)
+        output = cmd_output(*list(filter(None, cmd)), expected_code=0, prj_root=prj_root)
         print(output)
     except CalledProcessError as e:
         print(e.args[3])  # pragma: no mutate
@@ -369,6 +370,14 @@ def add_dbt_cmd_model_args(parser: argparse.ArgumentParser) -> NoReturn:
         help="""pre-commit-dbt is by default running changed files.
         If you need to override that, e.g. in case of Slim CI (state:modified),
         you can use this option.""",
+    )
+
+def add_dbt_cmd_prj_root(parser: argparse.ArgumentParser) -> NoReturn:
+    parser.add_argument(
+        "--prj-root",
+        type=str,
+        default=None,
+        help="Optional relative path to dbt project root directory.",
     )
 
 


### PR DESCRIPTION
This enhancement enables user to benefit from dbt-command hooks whenever their dbt project is not at the root level of the repo. 
It works by providing an additional argument to the dbt commands. 
Example:
hooks:
    - id: dbt-docs-generate
      files: ^projects/
      args: ["--prj-root","./common/dbt"]
    - id: dbt-deps
      files: ^projects/
      args: ["--prj-root","./common/dbt"]
      
In this example, the root of the dbt project is located inside the folder './commond/dbt'.

Addresses issue https://github.com/offbi/pre-commit-dbt/issues/39