### PR TITLE
Fix Github Action docker reference

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,6 @@ inputs:
     default: 'run --all-files'
 runs:
   using: 'docker'
-  image: 'docker://offbi:pre-commit-dbt:v1.0.0'
+  image: 'Dockerfile'
   args:
     - ${{ inputs.args}}


### PR DESCRIPTION
According to Github Actions documentation, we should reference the docker image directly from the project: https://docs.github.com/pt/actions/creating-actions/creating-a-docker-container-action#creating-an-action-metadata-file

This fixes: https://github.com/offbi/pre-commit-dbt/issues/26