### PR TITLE
add argument support to dbt commands (dbt clean & dbt deps)

### DIFF
--- a/pre_commit_dbt/dbt_clean.py
+++ b/pre_commit_dbt/dbt_clean.py
@@ -1,17 +1,30 @@
+import argparse
 from typing import List
 from typing import Optional
 from typing import Sequence
 
+from pre_commit_dbt.utils import add_dbt_cmd_args
+from pre_commit_dbt.utils import get_flags
 from pre_commit_dbt.utils import run_dbt_cmd
 
 
-def prepare_cmd() -> List[str]:
-    cmd = ["dbt", "clean"]
+def prepare_cmd(
+    global_flags: Optional[Sequence[str]] = None,
+    cmd_flags: Optional[Sequence[str]] = None,
+) -> List[str]:
+    global_flags = get_flags(global_flags)
+    cmd_flags = get_flags(cmd_flags)
+    cmd = ["dbt", *global_flags, "clean", *cmd_flags]
     return cmd
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
-    cmd = prepare_cmd()
+    parser = argparse.ArgumentParser()
+    add_dbt_cmd_args(parser)
+
+    args = parser.parse_args(argv)
+
+    cmd = docs_generate_cmd(args.global_flags, args.cmd_flags)
     return run_dbt_cmd(cmd)
 
 

--- a/pre_commit_dbt/dbt_clean.py
+++ b/pre_commit_dbt/dbt_clean.py
@@ -24,7 +24,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     args = parser.parse_args(argv)
 
-    cmd = docs_generate_cmd(args.global_flags, args.cmd_flags)
+    cmd = prepare_cmd(args.global_flags, args.cmd_flags)
     return run_dbt_cmd(cmd)
 
 

--- a/pre_commit_dbt/dbt_deps.py
+++ b/pre_commit_dbt/dbt_deps.py
@@ -1,17 +1,29 @@
+import argparse
 from typing import List
 from typing import Optional
 from typing import Sequence
 
+from pre_commit_dbt.utils import add_dbt_cmd_args
+from pre_commit_dbt.utils import get_flags
 from pre_commit_dbt.utils import run_dbt_cmd
 
-
-def prepare_cmd() -> List[str]:
-    cmd = ["dbt", "deps"]
+def prepare_cmd(
+    global_flags: Optional[Sequence[str]] = None,
+    cmd_flags: Optional[Sequence[str]] = None,
+) -> List[str]:
+    global_flags = get_flags(global_flags)
+    cmd_flags = get_flags(cmd_flags)
+    cmd = ["dbt", *global_flags, "deps", *cmd_flags]
     return cmd
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
-    cmd = prepare_cmd()
+    parser = argparse.ArgumentParser()
+    add_dbt_cmd_args(parser)
+
+    args = parser.parse_args(argv)
+
+    cmd = prepare_cmd(args.global_flags, args.cmd_flags)
     return run_dbt_cmd(cmd)
 
 

--- a/pre_commit_dbt/dbt_deps.py
+++ b/pre_commit_dbt/dbt_deps.py
@@ -7,6 +7,7 @@ from pre_commit_dbt.utils import add_dbt_cmd_args
 from pre_commit_dbt.utils import get_flags
 from pre_commit_dbt.utils import run_dbt_cmd
 
+
 def prepare_cmd(
     global_flags: Optional[Sequence[str]] = None,
     cmd_flags: Optional[Sequence[str]] = None,

--- a/tests/unit/test_dbt_clean.py
+++ b/tests/unit/test_dbt_clean.py
@@ -11,7 +11,7 @@ def test_dbt_clean():
             b"stderr",
         )
         mock_popen.return_value.returncode = 0
-        result = main()
+        result = main(argv=[])
         assert result == 0
 
 
@@ -22,7 +22,7 @@ def test_dbt_clean_error():
             b"stderr",
         )
         mock_popen.return_value.returncode = 1
-        result = main()
+        result = main(argv=[])
         assert result == 1
 
 

--- a/tests/unit/test_dbt_deps.py
+++ b/tests/unit/test_dbt_deps.py
@@ -11,7 +11,7 @@ def test_dbt_deps():
             b"stderr",
         )
         mock_popen.return_value.returncode = 0
-        result = main()
+        result = main(argv=[])
         assert result == 0
 
 
@@ -22,7 +22,7 @@ def test_dbt_deps_error():
             b"stderr",
         )
         mock_popen.return_value.returncode = 1
-        result = main()
+        result = main(argv=[])
         assert result == 1
 
 


### PR DESCRIPTION
This enhancement will allow the dbt-clean and dbt-deps hooks to take arguments for global and cmd flags.
This addresses issue [39](https://github.com/offbi/pre-commit-dbt/issues/39) by allowing the _project-dir_ flag to be added to the dbt clean and dbt deps commands
Example:
- id: dbt-clean
    args: ["--cmd-flags", "++project-dir", "./transform/dbt"] 