### PR TITLE
added an optional argument to fix the issue #36

### DIFF
--- a/pre_commit_dbt/check_script_has_no_table_name.py
+++ b/pre_commit_dbt/check_script_has_no_table_name.py
@@ -42,7 +42,7 @@ def add_space_to_parenthesis(sql: str) -> str:
 
 
 def has_table_name(
-    sql: str, filename: str, dotless: Optional[bool] = False
+    sql: str, filename: str, dotless: Optional[bool] = False, require2dots:Optional[bool] = False
 ) -> Tuple[int, Set[str]]:
     status_code = 0
     sql_clean = replace_comments(sql)
@@ -55,6 +55,8 @@ def has_table_name(
         if prev in ["from", "join"] and cur not in IGNORE_WORDS:
             table = cur.lower().strip().replace(",", "") if cur else cur
             if dotless and "." not in table:
+                pass
+            if require2dots and table.count(".")<2:
                 pass
             else:
                 tables.add(table)
@@ -74,6 +76,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     add_filenames_args(parser)
 
     parser.add_argument("--ignore-dotless-table", action="store_true")
+    parser.add_argument("--require-two-dots-table", action="store_true")
 
     args = parser.parse_args(argv)
     status_code = 0
@@ -81,7 +84,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     for filename in args.filenames:
         sql = Path(filename).read_text()
         status_code_file, tables = has_table_name(
-            sql, filename, args.ignore_dotless_table
+            sql, filename, args.ignore_dotless_table, args.require_two_dots_table
         )
         if status_code_file:
             result = "\n- ".join(list(tables))  # pragma: no mutate
@@ -96,3 +99,4 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
 if __name__ == "__main__":
     exit(main())
+

--- a/pre_commit_dbt/check_script_has_no_table_name.py
+++ b/pre_commit_dbt/check_script_has_no_table_name.py
@@ -56,8 +56,9 @@ def has_table_name(
             table = cur.lower().strip().replace(",", "") if cur else cur
             if dotless and "." not in table:
                 pass
-            if require2dots and table.count(".")<2:
-                pass
+            elif require2dots:
+                if table.count(".") ==2:
+                    tables.add(table)
             else:
                 tables.add(table)
         if (

--- a/pre_commit_dbt/check_script_has_no_table_name.py
+++ b/pre_commit_dbt/check_script_has_no_table_name.py
@@ -54,11 +54,10 @@ def has_table_name(
     for prev, cur, nxt in prev_cur_next_iter(sql_split):
         if prev in ["from", "join"] and cur not in IGNORE_WORDS:
             table = cur.lower().strip().replace(",", "") if cur else cur
-            if dotless and "." not in table:
+            if (dotless and "." not in table) or (require2dots and table.count(".") == 1):
                 pass
-            elif require2dots:
-                if table.count(".") ==2:
-                    tables.add(table)
+            elif require2dots and table.count(".") ==2:
+                tables.add(table)
             else:
                 tables.add(table)
         if (

--- a/tests/unit/test_check_script_has_no_table_name.py
+++ b/tests/unit/test_check_script_has_no_table_name.py
@@ -274,7 +274,8 @@ select * from unioned
 @pytest.mark.parametrize(("input_s", "args", "expected_status_code", "output"), TESTS)
 def test_has_table_name(input_s, args, expected_status_code, output):
     dotless = True if "--ignore-dotless-table" in args else False
-    ret, tables = has_table_name(input_s, "text.sql", dotless)
+    require2dots = True if "--require-two-dots-table" in args else False
+    ret, tables = has_table_name(input_s, "text.sql", dotless, require2dots)
     diff = tables.symmetric_difference(output)
     assert not diff
     assert ret == expected_status_code


### PR DESCRIPTION
Added an optional argument `--require-two-dots-table` to fix the issue #36. 

If `--require-two-dots-table` argument is passed in, this hook will still pass if there is less than 2 dots in the table name(like `cte.field`), but will still catch when the table name is hard-coded with two dots like `project.dataset.table`. 

This will also fix the issues like `EXTRACT(YEAR FROM date_field)` or `EXTRACT(YEAR FROM cte.date_field)`