### PR TITLE
Update Hooks.md, moved check-column-name-contract

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -2,11 +2,9 @@
 
 :bulb: Click on hook name to view the details.
 
-[`check-column-name-contract`]: https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-column-name-contract
-
 **Model checks:**
  * [`check-column-desc-are-same`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-column-desc-are-same): Check column descriptions are the same.
- * [`check-column-name-contract`](): Check column name abides to contract.
+ * [`check-column-name-contract`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-column-name-contract): Check column name abides to contract.
  * [`check-model-columns-have-desc`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-model-columns-have-desc): Check the model columns have description.
  * [`check-model-has-all-columns`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-model-has-all-columns): Check the model has all columns in the properties file.
  * [`check-model-has-description`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-model-has-description): Check the model has description.


### PR DESCRIPTION
 I have been getting this error when trying to use check-column-name-contract: 
[ERROR] `check-column-name-contract` is not present in repository https://github.com/offbi/pre-commit-dbt

I'm guessing this could be resolved by fixing the markdown file?  I'm not sure though