### PR TITLE
Fixed typo in code example of `dbt-compile`

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -1622,7 +1622,7 @@ repos:
  rev: v1.0.0
  hooks:
  - id: dbt-compile
-   args: ["--model-prefix". "+", "--"]
+   args: ["--model-prefix", "+", "--"]
 ```
 
 or


### PR DESCRIPTION
Replaced mistyped `.` with `,` in `args` to fix parsing error.

Example error:
```bash
An error has occurred: InvalidConfigError: 
==> File .pre-commit-config.yaml           
=====> while parsing a flow sequence       
  in "<unicode string>", line X, column Y
did not find expected ',' or ']'           
  in "<unicode string>", line X, column Y
```