### PR TITLE
Add check source has tests by group

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -186,7 +186,7 @@
   description: Ensures that the source has a number of tests of a certain group (unique, unique-combination-of-columns).
   entry: check-source-has-tests-by-group
   language: python
-  types_or: [yaml]
+  types_or: [sql, yaml]
 - id: check-source-has-tests
   name: Check the source has tests
   description: Ensures that the source has a number of tests.

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -181,6 +181,12 @@
   entry: check-source-has-tests-by-type
   language: python
   types_or: [yaml]
+- id: check-source-has-tests-by-group
+  name: Check the source tests by test group
+  description: Ensures that the source has a number of tests of a certain group (unique, unique-combination-of-columns).
+  entry: check-source-has-tests-by-group
+  language: python
+  types_or: [yaml]
 - id: check-source-has-tests
   name: Check the source has tests
   description: Ensures that the source has a number of tests.

--- a/HOOKS.md
+++ b/HOOKS.md
@@ -37,6 +37,7 @@
  * [`check-source-has-tests-by-name`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-source-has-tests-by-name): Check the source has a number of tests by test name.
  * [`check-source-has-tests-by-type`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-source-has-tests-by-type): Check the source has a number of tests by test type.
  * [`check-source-has-tests`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-source-has-tests): Check the source has a number of tests.
+ * [`check-source-has-tests-by-group`](https://github.com/cityblock/pre-commit-dbt/blob/main/HOOKS.md#check-source-has-tests-by-group): Check the source has a number of tests from a group of tests.
  * [`check-source-tags`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-source-tags): Check the source has valid tags.
  * [`check-source-childs`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-source-childs): Check the source has a specific number (max/min) of childs.
 
@@ -1189,6 +1190,47 @@ You want to make sure that every source was tested.
 - Hook takes all changed `yml`.
 - All sources from yml file are parsed.
 - If the source does not have the required test count, the hook fails.
+
+-----
+
+### `check-source-has-tests-by-group`
+
+Ensures that the source has a number of tests from a group of tests.
+
+#### Arguments
+
+`--tests`: list of test names.
+`--test_cnt`: number of tests required across test group.
+
+#### Example
+```
+repos:
+- repo: https://github.com/cityblock/pre-commit-dbt
+ rev: v1.0.0
+ hooks:
+ - id: check-source-has-tests-by-group
+   args: ["--tests", "unique", "unique_where", "--test-cnt", "1", "--"]
+```
+
+:warning: do not forget to include `--` as the last argument. Otherwise `pre-commit` would not be able to separate a list of files with args.
+
+#### When to use it
+
+You want to make sure that every source has one (or more) of a group of eligible tests (e.g. a set of unique tests).
+#### Requirements
+
+| Model exists in `manifest.json` <sup id="a1">[1](#f1)</sup> | Model exists in `catalog.json` <sup id="a2">[2](#f2)</sup> |
+| :----: | :----------: |
+| :white_check_mark: Yes| :x: Not needed |
+
+<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
+
+#### How it works
+
+- Hook takes all changed `SQL` files.
+- The source name is obtained from the `SQL` file name.
+- If any source does not have the number of required tests, the hook fails.
 
 -----
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ If this is the case, `pre-commit-dbt` is here to help you!
  * [`check-source-has-freshness`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-source-has-freshness): Check the source has the freshness.
  * [`check-source-has-loader`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-source-has-loader): Check the source has loader option.
  * [`check-source-has-meta-keys`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-source-has-meta-keys): Check the source has keys in the meta part.
+ * [`check-source-has-tests-by-group`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-source-has-tests-by-group): Check the source has a number of tests from a group of tests.
  * [`check-source-has-tests-by-name`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-source-has-tests-by-name): Check the source has a number of tests by test name.
  * [`check-source-has-tests-by-type`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-source-has-tests-by-type): Check the source has a number of tests by test type.
  * [`check-source-has-tests`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-source-has-tests): Check the source has a number of tests.

--- a/pre_commit_dbt/check_source_has_tests_by_group.py
+++ b/pre_commit_dbt/check_source_has_tests_by_group.py
@@ -1,0 +1,95 @@
+import argparse
+from itertools import groupby
+from typing import Any
+from typing import Dict
+from typing import Optional
+from typing import Sequence
+
+from pathlib import Path
+
+from pre_commit_dbt.utils import get_source_schemas
+from pre_commit_dbt.utils import add_filenames_args
+from pre_commit_dbt.utils import add_manifest_args
+from pre_commit_dbt.utils import get_json
+from pre_commit_dbt.utils import get_parent_childs
+from pre_commit_dbt.utils import JsonOpenError
+from pre_commit_dbt.utils import Test
+
+def check_test_cnt(
+    paths: Sequence[str],
+    manifest: Dict[str, Any],
+    test_group: Dict[str, int],
+    test_cnt: int,
+) -> int:
+    status_code = 0
+    ymls = [Path(path) for path in paths]
+    
+    # if user added schema but did not rerun
+    schemas = get_source_schemas(ymls)
+
+    for schema in schemas:
+        childs = list(
+            get_parent_childs(
+                manifest=manifest,
+                obj=schema,
+                manifest_node="child_map",
+                node_types=["test"],
+            )
+        )
+
+        tests = [test for test in childs if isinstance(test, Test)]
+        grouped = groupby(
+            sorted(tests, key=lambda x: x.test_name), lambda x: x.test_name
+        )
+        test_dict = {key: list(value) for key, value in grouped}
+        required_test_count = 0
+        for test in test_group:
+            if test_dict.get(test):
+                required_test_count += 1
+        
+        if required_test_count < test_cnt:
+            print(
+                f"{schema.source_name}.{schema.table_name}: "
+                f"has only {required_test_count} test(s) from {test_group}.",
+            )
+            status_code = 1
+    return status_code
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser()
+    add_filenames_args(parser)
+    add_manifest_args(parser)
+
+    parser.add_argument(
+        "--tests",
+        nargs="+",
+        required=True,
+        help="List of acceptable tests.",
+    )
+    parser.add_argument(
+        "--test-cnt",
+        type=int,
+        default=1,
+        help="Minimum number of tests required.",
+    )
+
+    args = parser.parse_args(argv)
+
+    try:
+        manifest = get_json(args.manifest)
+    except JsonOpenError as e:
+        print(f"Unable to load manifest file ({e})")
+        return 1
+
+    return check_test_cnt(
+        paths=args.filenames,
+        manifest=manifest,
+        test_group=args.tests,
+        test_cnt=args.test_cnt,
+    )
+
+
+if __name__ == "__main__":
+    exit(main())
+    

--- a/pre_commit_dbt/check_source_has_tests_by_group.py
+++ b/pre_commit_dbt/check_source_has_tests_by_group.py
@@ -92,4 +92,3 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
 if __name__ == "__main__":
     exit(main())
-    

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,7 @@ console_scripts =
     check-source-has-freshness = pre_commit_dbt.check_source_has_freshness:main
     check-source-has-loader = pre_commit_dbt.check_source_has_loader:main
     check-source-has-meta-keys = pre_commit_dbt.check_source_has_meta_keys:main
+    check-source-has-tests-by-group = pre_commit_dbt.check_source_has_tests_by_group:main
     check-source-has-tests-by-name = pre_commit_dbt.check_source_has_tests_by_name:main
     check-source-has-tests-by-type = pre_commit_dbt.check_source_has_tests_by_type:main
     check-source-has-tests = pre_commit_dbt.check_source_has_tests:main

--- a/tests/unit/test_check_source_has_tests_by_group.py
+++ b/tests/unit/test_check_source_has_tests_by_group.py
@@ -1,0 +1,75 @@
+import pytest
+
+from pre_commit_dbt.check_source_has_tests_by_group import main
+
+
+# Input schema, valid_manifest, input_args, expected return value
+TESTS = (
+    (
+        """
+sources:
+-   name: test
+    tables:
+    -   name: test1
+        description: test description
+    """,
+        True,
+        ["--tests", "unique", "--test-cnt", "1"],
+        0,
+    ),
+    (
+        """
+sources:
+-   name: test
+    tables:
+    -   name: test2
+        description: test description
+    """,
+        False,
+        ["--tests", "unique", "--test-cnt", "1"],
+        1,
+    ),
+    (
+        """
+sources:
+-   name: test
+    tables:
+    -   name: test3
+        description: test description
+    """,
+        True,
+        ["--tests", "", "--test-cnt", "2"],
+        1,
+    ),
+    (
+        """
+sources:
+-   name: test
+    tables:
+    -   name: test4
+        description: test description
+    """,
+        False,
+        ["--tests", "unique_combination_of_columns", "--test-cnt", "2"],
+        1,
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("input_schema", "valid_manifest", "input_args", "expected_status_code"), TESTS
+)
+def test_check_source_has_tests(
+    input_schema,
+    valid_manifest,
+    input_args,
+    expected_status_code,
+    manifest_path_str,
+    tmpdir,
+):
+    if valid_manifest:
+        input_args.extend(["--manifest", manifest_path_str])
+    yml_file = tmpdir.join("schema.yml")
+    yml_file.write(input_schema)
+    status_code = main(argv=[str(yml_file), *input_args])
+    assert status_code == expected_status_code


### PR DESCRIPTION
Solution for issue: https://github.com/dbt-checkpoint/dbt-checkpoint/issues/75

Added check_source_has_tests_by_group.py for a new hook that checks if a source has one or more tests within a test group. This hook enables searching of multiple types of tests on sources using OR logic, where any of the tests configured in the .yaml will cause the pre-commit check to pass.

This can be configured in the .pre-commit-config.yaml like so: 

```
    - id: check-source-has-tests-by-group
      args: ["--manifest", "dbt/target/manifest.json", "--tests", "unique", "unique_where", "unique_combination_of_columns", "--test-cnt", "1", "--"]
      name: check-source-has-tests-by-group
      verbose: true    
```

We tested this by running `pre-commit run check-source-has-tests-by-group` on a source with no uniqueness tests which proved failures, and then added a unique combination of columns test to the same source to prove passing.