### PR TITLE
fix: accommodate whitespaces for no table name check

### DIFF
--- a/pre_commit_dbt/check_script_has_no_table_name.py
+++ b/pre_commit_dbt/check_script_has_no_table_name.py
@@ -13,8 +13,9 @@ from pre_commit_dbt.utils import yellow
 
 REGEX_COMMENTS = r"(?<=(\/\*|\{#))((.|[\r\n])+?)(?=(\*+\/|#\}))|[ \t]*--.*"
 REGEX_SPLIT = r"[\s]+"
-IGNORE_WORDS = ["", "(", "{{"]  # pragma: no mutate
+IGNORE_WORDS = ["", "(", "{{", "{"]  # pragma: no mutate
 REGEX_PARENTHESIS = r"([\(\)])"  # pragma: no mutate
+REGEX_BRACES = r"([\{\}])"  # pragma: no mutate
 
 
 def prev_cur_next_iter(
@@ -41,6 +42,10 @@ def add_space_to_parenthesis(sql: str) -> str:
     return re.sub(REGEX_PARENTHESIS, r" \1 ", sql)
 
 
+def add_space_to_braces(sql: str) -> str:
+    return re.sub(REGEX_BRACES, r" \1 ", sql)
+
+
 def add_space_to_source_ref(sql: str) -> str:
     return sql.replace("{{", "{{ ").replace("}}", " }}")
 
@@ -51,6 +56,7 @@ def has_table_name(
     status_code = 0
     sql_clean = replace_comments(sql)
     sql_clean = add_space_to_parenthesis(sql_clean)
+    sql_clean = add_space_to_braces(sql_clean)
     sql_clean = add_space_to_source_ref(sql_clean)
     sql_split = re.split(REGEX_SPLIT, sql_clean)
     tables = set()

--- a/tests/unit/test_check_script_has_no_table_name.py
+++ b/tests/unit/test_check_script_has_no_table_name.py
@@ -269,6 +269,30 @@ select * from unioned
         1,
         {"aa.bb"},
     ),
+    (
+        """
+    with source as (
+        select * from {{source('aa', 'bb')}}
+    )
+    SELECT * FROM source
+    """,
+        [],
+        0,
+        {},
+    ),
+    (
+        """
+    {% macro source_cte(source_name, tuple_list) -%}
+    WITH{% for cte_ref in tuple_list %} {{cte_ref[0]}} AS (
+        SELECT * FROM {{ source(source_name, cte_ref[1]) }}
+    ),
+        {%- endfor %} final as (
+    {%- endmacro %}
+    """,
+        [],
+        0,
+        {},
+    ),
 )
 
 


### PR DESCRIPTION
This is a manual port of [pantonacci](https://github.com/pantonacci)'s [PR](https://github.com/Montreal-Analytics/dbt-gloss/pull/5) from dbt-gloss. Because dbt-gloss is technically not a fork and because it has significant path renaming, manual porting of changes is our best option for bringing in updates. 