### PR TITLE
fix: accommodate filter in src freshness

### DIFF
--- a/pre_commit_dbt/check_source_has_freshness.py
+++ b/pre_commit_dbt/check_source_has_freshness.py
@@ -21,6 +21,10 @@ def has_freshness(paths: Sequence[str], required_freshness: Set[str]) -> int:
         source = schema.source_schema
         table = schema.table_schema
         merged = {**source.get("freshness", {}), **table.get("freshness", {})}
+        # if filter is present, remove it because it's not a dictionary like
+        # warn_after or error_after
+        if "filter" in merged.keys():
+            merged.pop("filter")
         freshness = {
             key
             for key, value in merged.items()

--- a/tests/unit/test_check_source_has_freshness.py
+++ b/tests/unit/test_check_source_has_freshness.py
@@ -109,6 +109,21 @@ sources:
     """,
         1,
     ),
+    (
+        """
+sources:
+-   name: test
+    tables:
+    -   name: with_description
+        loaded_at_field: aa
+        freshness:
+            warn_after:
+                count: 12
+                period: hour
+            filter: field_a = condition_a
+    """,
+        1,
+    ),
 )
 
 


### PR DESCRIPTION
This is a manual port of [eliyarson](https://github.com/eliyarson)'s proposed [PR](https://github.com/Montreal-Analytics/dbt-gloss/pull/23) on dbt-gloss.

---

Description
---
When using optional freshness argument [`filter`](https://docs.getdbt.com/reference/resource-properties/freshness#filter) the hook `check_source_has_freshness.py` returns the following error:

```AttributeError: 'str' object has no attribute 'keys'```

It happens because the hook is expecting dictionaries (warn_after and error_after), but filter is a string.
A simple fix is to pop the key if it exists before checking for required keys as I did in the PR.

Obs: I had to change github flake8 pre-commit hook from gitlab to github because I don't have a gitlab acc, feel free to change back to gitlab if you guys think it's necessary.

Testing
---
```pytest tests/unit/test_check_source_has_freshness.py```
