### PR TITLE
[Fix] Limit check-source-has-tests-by-group hook to yaml files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -186,7 +186,7 @@
   description: Ensures that the source has a number of tests of a certain group (unique, unique-combination-of-columns).
   entry: check-source-has-tests-by-group
   language: python
-  types_or: [sql, yaml]
+  types_or: [yaml]
 - id: check-source-has-tests
   name: Check the source has tests
   description: Ensures that the source has a number of tests.

--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -232,21 +232,18 @@ def get_source_schemas(
 ) -> Generator[SourceSchema, None, None]:
     for yml_file in yml_files:
         schema = yaml.safe_load(yml_file.open())
-        try:
-            for source in schema.get("sources", []):
-                source_name = source.get("name")
-                tables = source.pop("tables", [])
-                for table in tables:
-                    table_name = table.get("name")
-                    yield SourceSchema(
-                        source_name=source_name,
-                        table_name=table_name,
-                        filename=yml_file.stem,
-                        source_schema=source,
-                        table_schema=table,
-                    )
-        except AttributeError:
-            pass
+        for source in schema.get("sources", []):
+            source_name = source.get("name")
+            tables = source.pop("tables", [])
+            for table in tables:
+                table_name = table.get("name")
+                yield SourceSchema(
+                    source_name=source_name,
+                    table_name=table_name,
+                    filename=yml_file.stem,
+                    source_schema=source,
+                    table_schema=table,
+                )
 
 
 def obj_in_deps(obj: Any, dep_name: str) -> bool:

--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -232,18 +232,21 @@ def get_source_schemas(
 ) -> Generator[SourceSchema, None, None]:
     for yml_file in yml_files:
         schema = yaml.safe_load(yml_file.open())
-        for source in schema.get("sources", []):
-            source_name = source.get("name")
-            tables = source.pop("tables", [])
-            for table in tables:
-                table_name = table.get("name")
-                yield SourceSchema(
-                    source_name=source_name,
-                    table_name=table_name,
-                    filename=yml_file.stem,
-                    source_schema=source,
-                    table_schema=table,
-                )
+        try:
+            for source in schema.get("sources", []):
+                source_name = source.get("name")
+                tables = source.pop("tables", [])
+                for table in tables:
+                    table_name = table.get("name")
+                    yield SourceSchema(
+                        source_name=source_name,
+                        table_name=table_name,
+                        filename=yml_file.stem,
+                        source_schema=source,
+                        table_schema=table,
+                    )
+        except AttributeError:
+            pass
 
 
 def obj_in_deps(obj: Any, dep_name: str) -> bool:


### PR DESCRIPTION
In #91, it was [my commit](https://github.com/dbt-checkpoint/dbt-checkpoint/pull/91/commits/ddde605c6a99b91c621db2aa2010a08d8accdc9a#diff-cb921d5df435fe404b4daf451cf783709ccebe9c346038af6036644e7386c13d) that inadvertently added `sql` to the `types_or` list for the `check-source-has-tests-by-group`.

I was naively pattern-matching based on the `check-model-has-tests-by-group` hook, and didn't think through the implications of the addition.

As we've started to use the new hook, we've run into an AttributeError that occurs when the hook is run over .sql files.

```
Check the source tests by test group.....................................Failed
- hook id: check-source-has-tests-by-group
- exit code: 1

Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repov8wo5h41/py_env-python3/bin/check-source-has-tests-by-group", line 8, in <module>
    sys.exit(main())
  File "/home/runner/.cache/pre-commit/repov8wo5h41/py_env-python3/lib/python3.10/site-packages/pre_commit_dbt/check_source_has_tests_by_group.py", line 85, in main
    return check_test_cnt(
  File "/home/runner/.cache/pre-commit/repov8wo5h41/py_env-python3/lib/python3.10/site-packages/pre_commit_dbt/check_source_has_tests_by_group.py", line 30, in check_test_cnt
    for schema in schemas:
  File "/home/runner/.cache/pre-commit/repov8wo5h41/py_env-python3/lib/python3.10/site-packages/pre_commit_dbt/utils.py", line 2[35](https://github.com/cityblock/data-platform/actions/runs/4255882670/jobs/7404092720#step:10:36), in get_source_schemas
    for source in schema.get("sources", []):
AttributeError: 'str' object has no attribute 'get'
```

By restoring the `types_or` to the appropriate value, the hook correctly skips SQL files that are passed in.

<img width="1103" alt="image" src="https://user-images.githubusercontent.com/46941959/221030483-81cf35a3-0166-4a26-9119-bff9d2780512.png">
