### PR TITLE
improve `get missing filepaths` utils logic

### DIFF
--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -430,13 +430,19 @@ def add_related_sqls(
     paths_with_missing: Set[str],
     include_ephemeral: bool = False,
 ) -> NoReturn:
+    yml_path_class = Path(yml_path)
+    yml_path_parts = list(yml_path_class.parts)
+    # Remove the first 'project' component
+    yml_path_parts.pop(0)
+    dbt_patch_path = "/".join(yml_path_parts)
+
     for key, node in nodes.items():  # pragma: no cover
         if (
             not include_ephemeral
             and node.get("config", {}).get("materialized") == "ephemeral"
         ):
             continue
-        if node.get("patch_path") and yml_path in node.get("patch_path"):
+        if node.get("patch_path") and dbt_patch_path in node.get("patch_path"):
             if ".sql" in node.get("path", "").lower():
                 for related_sql_file in Path().glob(f"**/{node.get('path')}"):
                     paths_with_missing.add(related_sql_file.as_posix())

--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -443,7 +443,7 @@ def add_related_sqls(
         ):
             continue
         if node.get("patch_path") and dbt_patch_path in node.get("patch_path"):
-            if ".sql" in node.get("path", "").lower():
+            if ".sql" in node.get("original_file_path", "").lower():
                 for related_sql_file in Path().glob(f"**/{node.get('path')}"):
                     paths_with_missing.add(related_sql_file.as_posix())
 

--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -471,7 +471,9 @@ def add_related_ymls(
                 patch_path = Path(patch_path)
                 clean_patch_path = patch_path.relative_to(*patch_path.parts[:1]).as_posix()
                 for related_yml_file in Path().glob(f'**/{clean_patch_path}'):
-                    paths_with_missing.add(related_yml_file.as_posix())
+                    yml_as_string = related_yml_file.as_posix()
+                    if 'target/' not in yml_as_string.lower():
+                        paths_with_missing.add(yml_as_string)
 
 def get_missing_file_paths(
     paths: Sequence[str],

--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -480,7 +480,6 @@ def get_missing_file_paths(
 ) -> List[str]:
     nodes = manifest.get("nodes", {})
     paths_with_missing = set(paths)
-    print(paths)
     if nodes:  # pragma: no cover
         for path in paths:
             suffix = Path(path).suffix.lower()
@@ -490,7 +489,6 @@ def get_missing_file_paths(
                 add_related_sqls(path, nodes, paths_with_missing, include_ephemeral)
             else:
                 continue
-    print(paths_with_missing)
     return paths_with_missing
 
 

--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -445,7 +445,9 @@ def add_related_sqls(
         if node.get("patch_path") and dbt_patch_path in node.get("patch_path"):
             if ".sql" in node.get("original_file_path", "").lower():
                 for related_sql_file in Path().glob(f"**/{node.get('original_file_path')}"):
-                    paths_with_missing.add(related_sql_file.as_posix())
+                    sql_as_string = related_sql_file.as_posix()
+                    if 'target/' not in sql_as_string.lower():
+                        paths_with_missing.add(sql_as_string)
 
 
 def add_related_ymls(

--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -444,7 +444,7 @@ def add_related_sqls(
             continue
         if node.get("patch_path") and dbt_patch_path in node.get("patch_path"):
             if ".sql" in node.get("original_file_path", "").lower():
-                for related_sql_file in Path().glob(f"**/{node.get('path')}"):
+                for related_sql_file in Path().glob(f"**/{node.get('original_file_path')}"):
                     paths_with_missing.add(related_sql_file.as_posix())
 
 

--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -472,7 +472,7 @@ def get_missing_file_paths(
 ) -> List[str]:
     nodes = manifest.get("nodes", {})
     paths_with_missing = set(paths)
-
+    print(paths)
     if nodes:  # pragma: no cover
         for path in paths:
             suffix = Path(path).suffix.lower()
@@ -482,6 +482,7 @@ def get_missing_file_paths(
                 add_related_sqls(path, nodes, paths_with_missing, include_ephemeral)
             else:
                 continue
+    print(paths_with_missing)
     return paths_with_missing
 
 

--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -3,16 +3,18 @@ import json
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
-from typing import Dict
-from typing import Generator
-from typing import List
-from typing import NoReturn
-from typing import Optional
-from typing import Sequence
-from typing import Set
-from typing import Text
-from typing import Union
+from typing import (
+    Any,
+    Dict,
+    Generator,
+    List,
+    NoReturn,
+    Optional,
+    Sequence,
+    Set,
+    Text,
+    Union,
+)
 
 import yaml
 
@@ -425,32 +427,27 @@ class ParseDict(argparse.Action):  # pragma: no cover
 def add_related_sqls(
     yml_path: str,
     nodes: Dict[Any, Any],
-    paths_with_missing: List[str],
+    paths_with_missing: Set[str],
     include_ephemeral: bool = False,
 ) -> NoReturn:
-    yml_path_class = Path(yml_path)
-    yml_path_parts = list(yml_path_class.parts)
-
-    root_path = yml_path_parts.pop(0)
-    dbt_patch_path = "/".join(yml_path_parts)
-
     for key, node in nodes.items():  # pragma: no cover
         if (
             not include_ephemeral
             and node.get("config", {}).get("materialized") == "ephemeral"
         ):
             continue
-        if node.get("patch_path") and dbt_patch_path in node.get("patch_path"):
-            if ".sql" in node["original_file_path"].lower():
-                target_sql_name = f"{root_path}/{node['original_file_path']}"
-                if target_sql_name not in paths_with_missing:
-                    paths_with_missing.append(target_sql_name)
+        if node.get("patch_path") and yml_path in node.get("patch_path"):
+            import ipdb
+            ipdb.set_trace()
+            if ".sql" in node.get("path", "").lower():
+                for related_sql_file in Path().glob(f"**/{node.get('path')}"):
+                    paths_with_missing.add(related_sql_file.as_posix())
 
 
 def add_related_ymls(
     sql_path: str,
     nodes: Dict[Any, Any],
-    paths_with_missing: List[str],
+    paths_with_missing: Set[str],
     include_ephemeral: bool = False,
 ) -> NoReturn:
     for key, node in nodes.items():  # pragma: no cover
@@ -463,17 +460,12 @@ def add_related_ymls(
         if node.get("path") and (node.get("path") in sql_path):
             patch_path = node.get("patch_path", None)
             if patch_path:
-                root_folder = Path(node["root_path"]).name
-
                 # Original patch_path has 'project\\path\to\yml.yml'
+                # Remove `project_name\\` from patch_path
                 patch_path = Path(patch_path)
-                # Remove the project_name from patch_path
-                clean_patch_path = patch_path.relative_to(*patch_path.parts[:1])
-
-                target_yml_path = f"{root_folder}/{clean_patch_path}"
-                if target_yml_path not in paths_with_missing:
-                    paths_with_missing.append(target_yml_path)
-
+                clean_patch_path = patch_path.relative_to(*patch_path.parts[:1]).as_posix()
+                for related_yml_file in Path().glob(f'**/{clean_patch_path}'):
+                    paths_with_missing.add(related_yml_file.as_posix())
 
 def get_missing_file_paths(
     paths: Sequence[str],
@@ -481,7 +473,7 @@ def get_missing_file_paths(
     include_ephemeral: bool = False,
 ) -> List[str]:
     nodes = manifest.get("nodes", {})
-    paths_with_missing = list(paths)
+    paths_with_missing = set(paths)
 
     if nodes:  # pragma: no cover
         for path in paths:

--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -437,8 +437,6 @@ def add_related_sqls(
         ):
             continue
         if node.get("patch_path") and yml_path in node.get("patch_path"):
-            import ipdb
-            ipdb.set_trace()
             if ".sql" in node.get("path", "").lower():
                 for related_sql_file in Path().glob(f"**/{node.get('path')}"):
                     paths_with_missing.add(related_sql_file.as_posix())


### PR DESCRIPTION
Replaced simple string work of `get_missing_file_paths` utils function for a proper pathlib.Path approach.

With these:
- Only existent files are added to hooks
- dbt project must no longer be nested in a subfolder: it can be at the same level of pre-commit-config.yml, or in any level of depth