### PR TITLE
make missing filepaths optional

### DIFF
--- a/dbt_checkpoint/check_model_columns_have_desc.py
+++ b/dbt_checkpoint/check_model_columns_have_desc.py
@@ -22,9 +22,9 @@ from dbt_checkpoint.utils import (
 
 
 def check_column_desc(
-    paths: Sequence[str], manifest: Dict[str, Any], include_missing: bool
+    paths: Sequence[str], manifest: Dict[str, Any], discover_files: bool
 ) -> Tuple[int, Dict[str, Any]]:
-    if include_missing:
+    if discover_files:
         paths = get_missing_file_paths(paths, manifest)
 
     status_code = 0
@@ -90,7 +90,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         return 1
 
     start_time = time.time()
-    status_code, _ = check_column_desc(paths=args.filenames, manifest=manifest, include_missing=args.include_missing)
+    status_code, _ = check_column_desc(paths=args.filenames, manifest=manifest, discover_files=args.discover_files)
     end_time = time.time()
     script_args = vars(args)
 

--- a/dbt_checkpoint/check_model_columns_have_desc.py
+++ b/dbt_checkpoint/check_model_columns_have_desc.py
@@ -22,9 +22,10 @@ from dbt_checkpoint.utils import (
 
 
 def check_column_desc(
-    paths: Sequence[str], manifest: Dict[str, Any]
+    paths: Sequence[str], manifest: Dict[str, Any], include_missing: bool
 ) -> Tuple[int, Dict[str, Any]]:
-    paths = get_missing_file_paths(paths, manifest)
+    if include_missing:
+        paths = get_missing_file_paths(paths, manifest)
 
     status_code = 0
     ymls = get_filenames(paths, [".yml", ".yaml"])
@@ -89,7 +90,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         return 1
 
     start_time = time.time()
-    status_code, _ = check_column_desc(paths=args.filenames, manifest=manifest)
+    status_code, _ = check_column_desc(paths=args.filenames, manifest=manifest, include_missing=args.include_missing)
     end_time = time.time()
     script_args = vars(args)
 

--- a/dbt_checkpoint/check_model_has_all_columns.py
+++ b/dbt_checkpoint/check_model_has_all_columns.py
@@ -28,12 +28,10 @@ def compare_columns(
 
 
 def check_model_columns(
-    paths: Sequence[str], manifest: Dict[str, Any], catalog: Dict[str, Any], include_missing: bool
+    paths: Sequence[str], manifest: Dict[str, Any], catalog: Dict[str, Any], discover_files: bool
 ) -> int:
-    print(paths)
-    if include_missing:
+    if discover_files:
         paths = get_missing_file_paths(paths, manifest)
-    print(paths)
     status_code = 0
     sqls = get_model_sqls(paths, manifest)
     filenames = set(sqls.keys())
@@ -105,7 +103,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     start_time = time.time()
     status_code = check_model_columns(
-        paths=args.filenames, manifest=manifest, catalog=catalog, include_missing=args.include_missing
+        paths=args.filenames, manifest=manifest, catalog=catalog, discover_files=args.discover_files
     )
     end_time = time.time()
     script_args = vars(args)

--- a/dbt_checkpoint/check_model_has_all_columns.py
+++ b/dbt_checkpoint/check_model_has_all_columns.py
@@ -28,9 +28,10 @@ def compare_columns(
 
 
 def check_model_columns(
-    paths: Sequence[str], manifest: Dict[str, Any], catalog: Dict[str, Any]
+    paths: Sequence[str], manifest: Dict[str, Any], catalog: Dict[str, Any], include_missing: bool
 ) -> int:
-    paths = get_missing_file_paths(paths, manifest)
+    if include_missing:
+        paths = get_missing_file_paths(paths, manifest)
 
     status_code = 0
     sqls = get_model_sqls(paths, manifest)
@@ -103,7 +104,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     start_time = time.time()
     status_code = check_model_columns(
-        paths=args.filenames, manifest=manifest, catalog=catalog
+        paths=args.filenames, manifest=manifest, catalog=catalog, include_missing=args.include_missing
     )
     end_time = time.time()
     script_args = vars(args)

--- a/dbt_checkpoint/check_model_has_all_columns.py
+++ b/dbt_checkpoint/check_model_has_all_columns.py
@@ -30,9 +30,10 @@ def compare_columns(
 def check_model_columns(
     paths: Sequence[str], manifest: Dict[str, Any], catalog: Dict[str, Any], include_missing: bool
 ) -> int:
+    print(paths)
     if include_missing:
         paths = get_missing_file_paths(paths, manifest)
-
+    print(paths)
     status_code = 0
     sqls = get_model_sqls(paths, manifest)
     filenames = set(sqls.keys())

--- a/dbt_checkpoint/check_model_has_description.py
+++ b/dbt_checkpoint/check_model_has_description.py
@@ -17,8 +17,8 @@ from dbt_checkpoint.utils import (
 )
 
 
-def has_description(paths: Sequence[str], manifest: Dict[str, Any], include_missing: bool) -> Dict[str, Any]:
-    if include_missing:
+def has_description(paths: Sequence[str], manifest: Dict[str, Any], discover_files: bool) -> Dict[str, Any]:
+    if discover_files:
         paths = get_missing_file_paths(paths, manifest)
 
     status_code = 0
@@ -60,7 +60,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         return 1
 
     start_time = time.time()
-    hook_properties = has_description(paths=args.filenames, manifest=manifest)
+    hook_properties = has_description(paths=args.filenames, manifest=manifest, discover_files=args.discover_files)
     end_time = time.time()
     script_args = vars(args)
 

--- a/dbt_checkpoint/check_model_has_description.py
+++ b/dbt_checkpoint/check_model_has_description.py
@@ -17,8 +17,9 @@ from dbt_checkpoint.utils import (
 )
 
 
-def has_description(paths: Sequence[str], manifest: Dict[str, Any]) -> Dict[str, Any]:
-    paths = get_missing_file_paths(paths, manifest)
+def has_description(paths: Sequence[str], manifest: Dict[str, Any], include_missing: bool) -> Dict[str, Any]:
+    if include_missing:
+        paths = get_missing_file_paths(paths, manifest)
 
     status_code = 0
     ymls = get_filenames(paths, [".yml", ".yaml"])

--- a/dbt_checkpoint/check_model_has_meta_keys.py
+++ b/dbt_checkpoint/check_model_has_meta_keys.py
@@ -33,9 +33,9 @@ def has_meta_key(
     manifest: Dict[str, Any],
     meta_keys: Sequence[str],
     allow_extra_keys: bool,
-    include_missing: bool
+    discover_files: bool
 ) -> int:
-    if include_missing:
+    if discover_files:
         paths = get_missing_file_paths(paths, manifest)
 
     status_code = 0
@@ -103,6 +103,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         manifest=manifest,
         meta_keys=args.meta_keys,
         allow_extra_keys=args.allow_extra_keys,
+        discover_files=args.discover_files
     )
     end_time = time.time()
     script_args = vars(args)

--- a/dbt_checkpoint/check_model_has_meta_keys.py
+++ b/dbt_checkpoint/check_model_has_meta_keys.py
@@ -33,8 +33,10 @@ def has_meta_key(
     manifest: Dict[str, Any],
     meta_keys: Sequence[str],
     allow_extra_keys: bool,
+    include_missing: bool
 ) -> int:
-    paths = get_missing_file_paths(paths, manifest)
+    if include_missing:
+        paths = get_missing_file_paths(paths, manifest)
 
     status_code = 0
     ymls = get_filenames(paths, [".yml", ".yaml"])

--- a/dbt_checkpoint/check_model_has_properties_file.py
+++ b/dbt_checkpoint/check_model_has_properties_file.py
@@ -16,9 +16,9 @@ from dbt_checkpoint.utils import (
 
 
 def has_properties_file(
-    paths: Sequence[str], manifest: Dict[str, Any], include_missing: bool
+    paths: Sequence[str], manifest: Dict[str, Any], discover_files: bool
 ) -> Tuple[int, Set[str]]:
-    if include_missing:
+    if discover_files:
         paths = get_missing_file_paths(paths, manifest)
 
     status_code = 0
@@ -53,7 +53,10 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         return 1
 
     start_time = time.time()
-    status_code, _ = has_properties_file(paths=args.filenames, manifest=manifest)
+    status_code, _ = has_properties_file(
+        paths=args.filenames, 
+        manifest=manifest,
+        discover_files=args.discover_files)
     end_time = time.time()
     script_args = vars(args)
 

--- a/dbt_checkpoint/check_model_has_properties_file.py
+++ b/dbt_checkpoint/check_model_has_properties_file.py
@@ -16,9 +16,10 @@ from dbt_checkpoint.utils import (
 
 
 def has_properties_file(
-    paths: Sequence[str], manifest: Dict[str, Any]
+    paths: Sequence[str], manifest: Dict[str, Any], include_missing: bool
 ) -> Tuple[int, Set[str]]:
-    paths = get_missing_file_paths(paths, manifest)
+    if include_missing:
+        paths = get_missing_file_paths(paths, manifest)
 
     status_code = 0
     sqls = get_model_sqls(paths, manifest)

--- a/dbt_checkpoint/check_model_has_tests.py
+++ b/dbt_checkpoint/check_model_has_tests.py
@@ -17,9 +17,9 @@ from dbt_checkpoint.utils import (
 
 
 def check_test_cnt(
-    paths: Sequence[str], manifest: Dict[str, Any], test_cnt: int, include_missing: bool
+    paths: Sequence[str], manifest: Dict[str, Any], test_cnt: int, discover_files: bool
 ) -> int:
-    if include_missing:
+    if discover_files:
         paths = get_missing_file_paths(paths, manifest)
 
     status_code = 0
@@ -70,7 +70,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     start_time = time.time()
     status_code = check_test_cnt(
-        paths=args.filenames, manifest=manifest, test_cnt=args.test_cnt, include_missing=args.include_missing
+        paths=args.filenames, manifest=manifest, test_cnt=args.test_cnt, discover_files=args.discover_files
     )
     end_time = time.time()
     script_args = vars(args)

--- a/dbt_checkpoint/check_model_has_tests.py
+++ b/dbt_checkpoint/check_model_has_tests.py
@@ -17,9 +17,10 @@ from dbt_checkpoint.utils import (
 
 
 def check_test_cnt(
-    paths: Sequence[str], manifest: Dict[str, Any], test_cnt: int
+    paths: Sequence[str], manifest: Dict[str, Any], test_cnt: int, include_missing: bool
 ) -> int:
-    paths = get_missing_file_paths(paths, manifest)
+    if include_missing:
+        paths = get_missing_file_paths(paths, manifest)
 
     status_code = 0
     sqls = get_model_sqls(paths, manifest)
@@ -69,7 +70,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     start_time = time.time()
     status_code = check_test_cnt(
-        paths=args.filenames, manifest=manifest, test_cnt=args.test_cnt
+        paths=args.filenames, manifest=manifest, test_cnt=args.test_cnt, include_missing=args.include_missing
     )
     end_time = time.time()
     script_args = vars(args)

--- a/dbt_checkpoint/check_model_has_tests_by_group.py
+++ b/dbt_checkpoint/check_model_has_tests_by_group.py
@@ -22,8 +22,10 @@ def check_test_cnt(
     manifest: Dict[str, Any],
     test_group: Dict[str, int],
     test_cnt: int,
+    include_missing: bool
 ) -> int:
-    paths = get_missing_file_paths(paths, manifest)
+    if include_missing:
+        paths = get_missing_file_paths(paths, manifest)
 
     status_code = 0
     sqls = get_model_sqls(paths, manifest)

--- a/dbt_checkpoint/check_model_has_tests_by_group.py
+++ b/dbt_checkpoint/check_model_has_tests_by_group.py
@@ -22,9 +22,9 @@ def check_test_cnt(
     manifest: Dict[str, Any],
     test_group: Dict[str, int],
     test_cnt: int,
-    include_missing: bool
+    discover_files: bool
 ) -> int:
-    if include_missing:
+    if discover_files:
         paths = get_missing_file_paths(paths, manifest)
 
     status_code = 0
@@ -91,6 +91,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         manifest=manifest,
         test_group=args.tests,
         test_cnt=args.test_cnt,
+        discover_files=args.discover_files
     )
     end_time = time.time()
     script_args = vars(args)

--- a/dbt_checkpoint/check_model_has_tests_by_name.py
+++ b/dbt_checkpoint/check_model_has_tests_by_name.py
@@ -19,9 +19,9 @@ from dbt_checkpoint.utils import (
 
 
 def check_test_cnt(
-    paths: Sequence[str], manifest: Dict[str, Any], required_tests: Dict[str, int], include_missing: bool
+    paths: Sequence[str], manifest: Dict[str, Any], required_tests: Dict[str, int], discover_files: bool
 ) -> int:
-    if include_missing:
+    if discover_files:
         paths = get_missing_file_paths(paths, manifest)
     status_code = 0
     sqls = get_model_sqls(paths, manifest)
@@ -94,7 +94,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     end_time = time.time()
 
     status_code = check_test_cnt(
-        paths=args.filenames, manifest=manifest, required_tests=required_tests
+        paths=args.filenames, manifest=manifest, required_tests=required_tests, discover_files=args.discover_files
     )
     script_args = vars(args)
 

--- a/dbt_checkpoint/check_model_has_tests_by_name.py
+++ b/dbt_checkpoint/check_model_has_tests_by_name.py
@@ -19,9 +19,10 @@ from dbt_checkpoint.utils import (
 
 
 def check_test_cnt(
-    paths: Sequence[str], manifest: Dict[str, Any], required_tests: Dict[str, int]
+    paths: Sequence[str], manifest: Dict[str, Any], required_tests: Dict[str, int], include_missing: bool
 ) -> int:
-    paths = get_missing_file_paths(paths, manifest)
+    if include_missing:
+        paths = get_missing_file_paths(paths, manifest)
     status_code = 0
     sqls = get_model_sqls(paths, manifest)
     filenames = set(sqls.keys())

--- a/dbt_checkpoint/check_model_has_tests_by_type.py
+++ b/dbt_checkpoint/check_model_has_tests_by_type.py
@@ -19,9 +19,9 @@ from dbt_checkpoint.utils import (
 
 
 def check_test_cnt(
-    paths: Sequence[str], manifest: Dict[str, Any], required_tests: Dict[str, int], include_missing: bool
+    paths: Sequence[str], manifest: Dict[str, Any], required_tests: Dict[str, int], discover_files: bool
 ) -> int:
-    if include_missing:
+    if discover_files:
         paths = get_missing_file_paths(paths, manifest)
 
     status_code = 0
@@ -101,7 +101,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     end_time = time.time()
 
     status_code = check_test_cnt(
-        paths=args.filenames, manifest=manifest, required_tests=required_tests
+        paths=args.filenames, manifest=manifest, required_tests=required_tests, discover_files=args.discover_files
     )
 
     script_args = vars(args)

--- a/dbt_checkpoint/check_model_has_tests_by_type.py
+++ b/dbt_checkpoint/check_model_has_tests_by_type.py
@@ -19,9 +19,10 @@ from dbt_checkpoint.utils import (
 
 
 def check_test_cnt(
-    paths: Sequence[str], manifest: Dict[str, Any], required_tests: Dict[str, int]
+    paths: Sequence[str], manifest: Dict[str, Any], required_tests: Dict[str, int], include_missing: bool
 ) -> int:
-    paths = get_missing_file_paths(paths, manifest)
+    if include_missing:
+        paths = get_missing_file_paths(paths, manifest)
 
     status_code = 0
     sqls = get_model_sqls(paths, manifest)

--- a/dbt_checkpoint/check_model_parents_and_childs.py
+++ b/dbt_checkpoint/check_model_parents_and_childs.py
@@ -20,9 +20,9 @@ def check_child_parent_cnt(
     paths: Sequence[str],
     manifest: Dict[str, Any],
     required_cnt: Sequence[Dict[str, Any]],
-    include_missing: bool
+    discover_files: bool
 ) -> int:
-    if include_missing:
+    if discover_files:
         paths = get_missing_file_paths(paths, manifest)
 
     status_code = 0
@@ -133,7 +133,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     ]
     start_time = time.time()
     status_code = check_child_parent_cnt(
-        paths=args.filenames, manifest=manifest, required_cnt=required_cnt
+        paths=args.filenames, manifest=manifest, required_cnt=required_cnt, discover_files=args.discover_files
     )
     end_time = time.time()
     script_args = vars(args)

--- a/dbt_checkpoint/check_model_parents_and_childs.py
+++ b/dbt_checkpoint/check_model_parents_and_childs.py
@@ -20,8 +20,10 @@ def check_child_parent_cnt(
     paths: Sequence[str],
     manifest: Dict[str, Any],
     required_cnt: Sequence[Dict[str, Any]],
+    include_missing: bool
 ) -> int:
-    paths = get_missing_file_paths(paths, manifest)
+    if include_missing:
+        paths = get_missing_file_paths(paths, manifest)
 
     status_code = 0
     sqls = get_model_sqls(paths, manifest)

--- a/dbt_checkpoint/check_model_parents_database.py
+++ b/dbt_checkpoint/check_model_parents_database.py
@@ -20,8 +20,10 @@ def check_parents_database(
     manifest: Dict[str, Any],
     blacklist: Optional[Sequence[str]],
     whitelist: Optional[Sequence[str]],
+    include_missing: bool
 ) -> int:
-    paths = get_missing_file_paths(paths, manifest)
+    if include_missing:
+        paths = get_missing_file_paths(paths, manifest)
 
     status_code = 0
     sqls = get_filenames(paths, [".sql"])

--- a/dbt_checkpoint/check_model_parents_database.py
+++ b/dbt_checkpoint/check_model_parents_database.py
@@ -20,9 +20,9 @@ def check_parents_database(
     manifest: Dict[str, Any],
     blacklist: Optional[Sequence[str]],
     whitelist: Optional[Sequence[str]],
-    include_missing: bool
+    discover_files: bool
 ) -> int:
-    if include_missing:
+    if discover_files:
         paths = get_missing_file_paths(paths, manifest)
 
     status_code = 0
@@ -91,6 +91,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         manifest=manifest,
         blacklist=args.blacklist,
         whitelist=args.whitelist,
+        discover_files=args.discover_files
     )
     end_time = time.time()
     script_args = vars(args)

--- a/dbt_checkpoint/check_model_parents_schema.py
+++ b/dbt_checkpoint/check_model_parents_schema.py
@@ -20,8 +20,10 @@ def check_parents_schema(
     manifest: Dict[str, Any],
     blacklist: Optional[Sequence[str]],
     whitelist: Optional[Sequence[str]],
+    include_missing: bool
 ) -> int:
-    paths = get_missing_file_paths(paths, manifest)
+    if include_missing:
+        paths = get_missing_file_paths(paths, manifest)
 
     status_code = 0
     sqls = get_filenames(paths, [".sql"])

--- a/dbt_checkpoint/check_model_parents_schema.py
+++ b/dbt_checkpoint/check_model_parents_schema.py
@@ -20,9 +20,9 @@ def check_parents_schema(
     manifest: Dict[str, Any],
     blacklist: Optional[Sequence[str]],
     whitelist: Optional[Sequence[str]],
-    include_missing: bool
+    discover_files: bool
 ) -> int:
-    if include_missing:
+    if discover_files:
         paths = get_missing_file_paths(paths, manifest)
 
     status_code = 0
@@ -91,6 +91,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         manifest=manifest,
         blacklist=args.blacklist,
         whitelist=args.whitelist,
+        discover_files=args.discover_files
     )
     end_time = time.time()
     script_args = vars(args)

--- a/dbt_checkpoint/check_model_tags.py
+++ b/dbt_checkpoint/check_model_tags.py
@@ -15,9 +15,10 @@ from dbt_checkpoint.utils import (
 
 
 def validate_tags(
-    paths: Sequence[str], manifest: Dict[str, Any], tags: Sequence[str]
+    paths: Sequence[str], manifest: Dict[str, Any], tags: Sequence[str], include_missing: bool
 ) -> int:
-    paths = get_missing_file_paths(paths, manifest)
+    if include_missing:
+        paths = get_missing_file_paths(paths, manifest)
 
     status_code = 0
     sqls = get_model_sqls(paths, manifest)

--- a/dbt_checkpoint/check_model_tags.py
+++ b/dbt_checkpoint/check_model_tags.py
@@ -15,9 +15,9 @@ from dbt_checkpoint.utils import (
 
 
 def validate_tags(
-    paths: Sequence[str], manifest: Dict[str, Any], tags: Sequence[str], include_missing: bool
+    paths: Sequence[str], manifest: Dict[str, Any], tags: Sequence[str], discover_files: bool
 ) -> int:
-    if include_missing:
+    if discover_files:
         paths = get_missing_file_paths(paths, manifest)
 
     status_code = 0
@@ -61,7 +61,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         return 1
 
     start_time = time.time()
-    status_code = validate_tags(paths=args.filenames, manifest=manifest, tags=args.tags)
+    status_code = validate_tags(paths=args.filenames, manifest=manifest, tags=args.tags, discover_files=args.discover_files)
     end_time = time.time()
     script_args = vars(args)
 

--- a/dbt_checkpoint/utils.py
+++ b/dbt_checkpoint/utils.py
@@ -397,11 +397,20 @@ def add_tracking_args(parser: argparse.ArgumentParser) -> NoReturn:
     )
 
 
+def add_missing_filenames_args(parser: argparse.ArgumentParser) -> NoReturn:
+    parser.add_argument(
+        "--include-missing",
+        action="store_true",
+        help="Discover sql/yml files related to the ones subject of hooks"
+    )
+
+
 def add_default_args(parser: argparse.ArgumentParser) -> NoReturn:
     add_filenames_args(parser)
     add_manifest_args(parser)
     add_config_args(parser)
     add_tracking_args(parser)
+    add_missing_filenames_args(parser)
 
 
 def add_dbt_cmd_args(parser: argparse.ArgumentParser) -> NoReturn:

--- a/dbt_checkpoint/utils.py
+++ b/dbt_checkpoint/utils.py
@@ -388,15 +388,7 @@ def add_tracking_args(parser: argparse.ArgumentParser) -> None:
 
 def add_missing_filenames_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
-        "--include-missing",
-        action="store_true",
-        help="Discover sql/yml files related to the ones subject of hooks"
-    )
-
-
-def add_missing_filenames_args(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument(
-        "--include-missing",
+        "--discover-files",
         action="store_true",
         help="Discover sql/yml files related to the ones subject of hooks"
     )


### PR DESCRIPTION
This PR aims to fix Issue #108 by making `get_missing_filepaths` optional, which has to be enabled with the `--discover-files` flag

for example:

```yaml
repos:
  - repo: https://github.com/dbt-checkpoint/dbt-checkpoint
    rev: v1.1.0
    files: ^transform/models/
    hooks:
      - id: check-model-has-description
        args: ["--manifest", "transform/target/manifest.json", "--discover-files"]
```