### PR TITLE
Fix: Add .dbt-checkpoint.yaml to disable hook execution tracking in mixpanel

### DIFF
--- a/.dbt-checkpoint.yaml
+++ b/.dbt-checkpoint.yaml
@@ -1,0 +1,2 @@
+version: 1
+disable-tracking: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,36 +1,37 @@
 repos:
-    - repo: https://github.com/psf/black
-      rev: 22.3.0
-      hooks:
-          - id: black
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v3.4.0
-      hooks:
-          - id: trailing-whitespace
-          - id: end-of-file-fixer
-          - id: check-docstring-first
-          - id: check-added-large-files
-          - id: debug-statements
-          - id: name-tests-test
-            args: ["--django"]
-    - repo: https://gitlab.com/pycqa/flake8
-      rev: 3.8.4
-      hooks:
-          - id: flake8
-            additional_dependencies:
-                - flake8-absolute-import
-                - flake8-black
-                - flake8-comprehensions
-    - repo: https://github.com/asottile/reorder_python_imports
-      rev: v2.3.6
-      hooks:
-          - id: reorder-python-imports
-            args: [--py3-plus]
-    - repo: https://github.com/asottile/setup-cfg-fmt
-      rev: v1.16.0
-      hooks:
-          - id: setup-cfg-fmt
-    - repo: https://github.com/pre-commit/mirrors-mypy
-      rev: v0.790
-      hooks:
-          - id: mypy
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-docstring-first
+      - id: check-added-large-files
+      - id: debug-statements
+      - id: name-tests-test
+        args: ["--django"]
+  - repo: https://github.com/PyCQA/flake8
+    rev: 3.8.4
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-absolute-import
+          - flake8-black
+          - flake8-comprehensions
+  - repo: https://github.com/asottile/reorder_python_imports
+    rev: v2.3.6
+    hooks:
+      - id: reorder-python-imports
+        args: [--py3-plus]
+  - repo: https://github.com/asottile/setup-cfg-fmt
+    rev: v1.16.0
+    hooks:
+      - id: setup-cfg-fmt
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.940
+    hooks:
+      - id: mypy
+        additional_dependencies: ["types-PyYAML"]

--- a/dbt_checkpoint/check_model_has_description.py
+++ b/dbt_checkpoint/check_model_has_description.py
@@ -1,26 +1,27 @@
 import argparse
 import os
 import time
-from typing import Any, Dict, Optional, Sequence
+from typing import Any
+from typing import Dict
+from typing import Optional
+from typing import Sequence
 
 from dbt_checkpoint.tracking import dbtCheckpointTracking
-from dbt_checkpoint.utils import (
-    JsonOpenError,
-    add_default_args,
-    get_filenames,
-    get_json,
-    get_missing_file_paths,
-    get_model_schemas,
-    get_model_sqls,
-    get_models,
-    red,
-)
+from dbt_checkpoint.utils import add_default_args
+from dbt_checkpoint.utils import get_filenames
+from dbt_checkpoint.utils import get_json
+from dbt_checkpoint.utils import get_missing_file_paths
+from dbt_checkpoint.utils import get_model_schemas
+from dbt_checkpoint.utils import get_model_sqls
+from dbt_checkpoint.utils import get_models
+from dbt_checkpoint.utils import JsonOpenError
+from dbt_checkpoint.utils import red
 
 
 def has_description(
     paths: Sequence[str], manifest: Dict[str, Any], exclude_pattern: str
 ) -> Dict[str, Any]:
-    paths = get_missing_file_paths(
+    paths = get_missing_file_paths(  # type: ignore
         paths, manifest, extensions=[".yml", ".yaml"], exclude_pattern=exclude_pattern
     )
 
@@ -82,7 +83,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         },
     )
 
-    return hook_properties.get("status_code")
+    return hook_properties.get("status_code")  # type: ignore
 
 
 if __name__ == "__main__":

--- a/dbt_checkpoint/utils.py
+++ b/dbt_checkpoint/utils.py
@@ -4,7 +4,15 @@ import re
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Generator, List, Optional, Sequence, Set, Text, Union
+from typing import Any
+from typing import Dict
+from typing import Generator
+from typing import List
+from typing import Optional
+from typing import Sequence
+from typing import Set
+from typing import Text
+from typing import Union
 
 from yaml import safe_load
 
@@ -554,11 +562,11 @@ def add_related_ymls(
                         paths_with_missing.add(yml_as_string)
 
 
-def _discover_sql_files(node):
+def _discover_sql_files(node):  # type: ignore
     return Path().glob(f"**/{node.get('original_file_path')}")
 
 
-def _discover_prop_files(model_path):
+def _discover_prop_files(model_path):  # type: ignore
     return Path().glob(f"**/{model_path}")
 
 
@@ -582,7 +590,7 @@ def get_missing_file_paths(
                 continue
     if exclude_pattern:
         exclude_re = re.compile(exclude_pattern)
-        paths_with_missing = [
+        paths_with_missing = [  # type: ignore
             filename
             for filename in paths_with_missing
             if not exclude_re.search(filename)

--- a/tests/unit/test_check_model_columns_have_desc.py
+++ b/tests/unit/test_check_model_columns_have_desc.py
@@ -1,8 +1,10 @@
-from unittest.mock import mock_open, patch
+from unittest.mock import mock_open
+from unittest.mock import patch
 
 import pytest
 
-from dbt_checkpoint.check_model_columns_have_desc import check_column_desc, main
+from dbt_checkpoint.check_model_columns_have_desc import check_column_desc
+from dbt_checkpoint.check_model_columns_have_desc import main
 
 # Input args, valid manifest, expected return value
 TESTS = (
@@ -21,6 +23,7 @@ TESTS = (
             ]
         },
         True,
+        True,
         0,
     ),
     (
@@ -38,6 +41,7 @@ TESTS = (
             ]
         },
         False,
+        True,
         1,
     ),
     (
@@ -54,6 +58,7 @@ TESTS = (
                 }
             ]
         },
+        True,
         True,
         1,
     ),
@@ -72,23 +77,33 @@ TESTS = (
             ]
         },
         True,
+        True,
         1,
     ),
 )
 
 
 @pytest.mark.parametrize(
-    ("input_args", "schema", "valid_manifest", "expected_status_code"), TESTS
+    ("input_args", "schema", "valid_manifest", "valid_config", "expected_status_code"),
+    TESTS,
 )
 def test_check_model_columns_have_desc(
-    input_args, schema, valid_manifest, expected_status_code, manifest_path_str
+    input_args,
+    schema,
+    valid_manifest,
+    valid_config,
+    expected_status_code,
+    manifest_path_str,
+    config_path_str,
 ):
     if valid_manifest:
         input_args.extend(["--manifest", manifest_path_str])
+    if valid_config:
+        input_args.extend(["--config", config_path_str])
     with patch("builtins.open", mock_open(read_data="data")):
         with patch("dbt_checkpoint.utils.safe_load") as mock_safe_load:
             mock_safe_load.return_value = schema
-            status_code = main(input_args)
+    status_code = main(input_args)
     assert status_code == expected_status_code
 
 

--- a/tests/unit/test_check_model_has_description.py
+++ b/tests/unit/test_check_model_has_description.py
@@ -1,4 +1,5 @@
-from unittest.mock import mock_open, patch
+from unittest.mock import mock_open
+from unittest.mock import patch
 
 import pytest
 
@@ -10,41 +11,47 @@ TESTS = (
         ["aa/bb/with_description.sql"],
         {"models": [{"name": "with_description", "description": "test description"}]},
         True,
+        True,
         0,
     ),
     (
         ["aa/bb/with_description.sql"],
         {"models": [{"name": "with_description", "description": "test description"}]},
         False,
+        True,
         1,
     ),
     (
         ["aa/bb/without_description.sql"],
-        {
-            "models": [
-                {
-                    "name": "without_description",
-                }
-            ]
-        },
+        {"models": [{"name": "without_description"}]},
         True,
+        False,
         1,
     ),
 )
 
 
 @pytest.mark.parametrize(
-    ("input_args", "schema", "valid_manifest", "expected_status_code"), TESTS
+    ("input_args", "schema", "valid_manifest", "valid_config", "expected_status_code"),
+    TESTS,
 )
 def test_check_model_description(
-    input_args, schema, valid_manifest, expected_status_code, manifest_path_str
+    input_args,
+    schema,
+    valid_manifest,
+    valid_config,
+    expected_status_code,
+    manifest_path_str,
+    config_path_str,
 ):
     if valid_manifest:
         input_args.extend(["--manifest", manifest_path_str])
+    if valid_config:
+        input_args.extend(["--config", config_path_str])
     with patch("builtins.open", mock_open(read_data="data")):
         with patch("dbt_checkpoint.utils.safe_load") as mock_safe_load:
             mock_safe_load.return_value = schema
-            status_code = main(input_args)
+    status_code = main(input_args)
     assert status_code == expected_status_code
 
 


### PR DESCRIPTION
Fix: Add `.dbt-checkpoint.yaml` to disable hook execution tracking in mixpanel

## Description & motivation
- updated` flake8` github repo link in the pre-commit-config.yaml
- updated `mirrors-mypy` version and added `additional_dependencies` in the pre-commit-config.yaml
- ignored mypy errors in `utils.py` and `check_model_has_description.py`
- added `--valid_config` as an input argument to 
         `test_check_model_has_meta_keys.py`
         `test_check_model_has_description.py`
         `test_check_model_columns_have_desc.py`
         
## Validation of models:
Results of `pytest`
<img width="1385" alt="image" src="https://github.com/dbt-checkpoint/dbt-checkpoint/assets/101433328/b714e526-ecb8-4dd9-81f0-a0b0d129b702">

Results of `pre-commit run `
<img width="933" alt="image" src="https://github.com/dbt-checkpoint/dbt-checkpoint/assets/101433328/640e5590-6b32-48ec-b022-e3457aa38fb9">

## Checklist:
<!---
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.
Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.
-->
- [x] My pull request represents one logical piece of work.
- [x] My commits are related to the pull request and look clean.
- [ ] I have updated the README file.
