### PR TITLE
Adding dbt parse hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -237,6 +237,13 @@
   entry: dbt-docs-generate
   language: python
   pass_filenames: false
+- id: dbt-parse
+  name: dbt parse
+  description: Generates manifest.json from source model, test, and analysis files.
+  entry: dbt-parse
+  language: python
+  types_or: [sql]
+  require_serial: true
 - id: dbt-run
   name: dbt run
   description: Executes compiled sql model files.

--- a/HOOKS.md
+++ b/HOOKS.md
@@ -144,7 +144,7 @@ E.g. in two of your models, you have `customer_id` with the description `This is
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |   :x: Not needed since it also validates properties files   |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -189,7 +189,7 @@ You want to make sure your columns follow a contract, e.g. all your boolean colu
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                       :x: Not needed                        |                   :white_check_mark: Yes                   |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -230,7 +230,7 @@ You want to make sure that all specified columns in the properties files (usuall
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |   :x: Not needed since it also validates properties files   |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -278,7 +278,7 @@ You want to make sure that you have all the database columns listed in the prope
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                   :white_check_mark: Yes                   |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -324,7 +324,7 @@ You want to make sure that all models have a description.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |   :x: Not needed since it also validates properties files   |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -377,7 +377,7 @@ If every model needs to have certain meta keys.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |   :x: Not needed since it also validates properties files   |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -430,7 +430,7 @@ If every model needs to have certain labels keys.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |   :x: Not needed since it also validates properties files   |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -476,7 +476,7 @@ You want to make sure that every model has a properties file.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -525,7 +525,7 @@ You want to make sure that every model has certain tests.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -570,7 +570,7 @@ You want to make sure that every model has certain tests.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -616,7 +616,7 @@ You want to make sure that every model has one (or more) of a group of eligible 
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -661,7 +661,7 @@ You want to make sure that every model was tested.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -707,7 +707,7 @@ You want to make sure your model names follow a naming convention (e.g., staging
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                       :x: Not needed                        |                   :white_check_mark: Yes                   |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -754,7 +754,7 @@ You want to find orphaned models (empty file, hard-coded reference, etc.). Or yo
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -800,7 +800,7 @@ You want to be sure that certain models are using only models from specified dat
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -845,7 +845,7 @@ You want to be sure that certain models are using only models from specified sch
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -890,7 +890,7 @@ Make sure you did not typo in tags.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -931,7 +931,7 @@ Make sure to increase the efficiency within your dbt run and make use of good ma
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 ### `check-script-ref-and-source`
@@ -962,7 +962,7 @@ Make sure you have only valid ref and sources in your script and you do not want
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 ### `check-script-semicolon`
@@ -996,7 +996,7 @@ Make sure you did not provide a semicolon at the end of the file.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1034,7 +1034,7 @@ To make sure that you have only refs and sources in your `SQL` files.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                       :x: Not needed                        |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1068,7 +1068,7 @@ You want to make sure that all specified columns in the properties files (usuall
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                             :x:                             |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1108,7 +1108,7 @@ You want to make sure that you have all the database columns listed in the prope
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                           :x: No                            |                   :white_check_mark: Yes                   |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1148,7 +1148,7 @@ You want to make sure that all sources have a description.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                       :x: Not needed                        |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1186,7 +1186,7 @@ You want to make sure that all freshness is correctly set.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                       :x: Not needed                        |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1221,7 +1221,7 @@ You want to make sure that the source has loader specified.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                       :x: Not needed                        |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1263,7 +1263,7 @@ If every source needs to have certain meta keys.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |   :x: Not needed since it also validates properties files   |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1305,7 +1305,7 @@ If every source needs to have certain labels keys.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |   :x: Not needed since it also validates properties files   |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1347,7 +1347,7 @@ You want to make sure that every source has certain tests.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                           :x: Yes                           |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1389,7 +1389,7 @@ You want to make sure that every source has certain tests.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                           :x: Yes                           |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1431,7 +1431,7 @@ You want to make sure that every source was tested.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                           :x: Yes                           |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1474,7 +1474,7 @@ You want to make sure that every source has one (or more) of a group of eligible
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1516,7 +1516,7 @@ Make sure you did not typo in tags.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                       :x: Not needed                        |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1560,7 +1560,7 @@ You want to find orphaned sources without any dependencies. Or you want to make 
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1601,7 +1601,7 @@ You want to make sure that all macros have a description.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |   :x: Not needed since it also validates properties files   |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1647,7 +1647,7 @@ You want to make sure that all specified arguments in the properties files (usua
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |   :x: Not needed since it also validates properties files   |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1697,7 +1697,7 @@ You are too lazy to define schemas manually :D.
 | :-----------------------------------------------------------------------: | :--------------------------------------------------------: |
 | :x: Not needed since this hook tries to generate even non-existent source |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1754,7 +1754,7 @@ You want the descriptions of the same columns to be the same. E.g. in two of you
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |   :x: Not needed since this hook is using only yaml files   |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1800,7 +1800,7 @@ You are running and debugging your `SQL` in the editor. This editor does not kno
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1847,7 +1847,7 @@ You are running and debugging your `SQL` in the editor. This editor does not kno
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                          :x: Yes                           |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1888,7 +1888,7 @@ You are too lazy or forgetful to delete one character at the end of the script.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                       :x: Not needed                        |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1986,7 +1986,7 @@ repos:
 
 ### `dbt-parse`
 
-Run the` dbt parse` command. Generates `manifest.json` from source model, test, and analysis files.
+Run the` dbt parse` command. When running dbt >= 1.5, generates `manifest.json` from source model, test, and analysis files.
 
 #### Arguments
 
@@ -2129,7 +2129,7 @@ If every macro needs to have certain meta keys.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -2180,7 +2180,7 @@ If every seed needs to have certain meta keys.
 | :--------------------------------------------------------: | :-------------------------------------------------------: |
 |                   :white_check_mark: Yes                   |                      :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -2231,7 +2231,7 @@ If every snapshot needs to have certain meta keys.
 | :------------------------------------------------------------: | :-----------------------------------------------------------: |
 |                            :x: Not                             |                        :x: Not needed                         |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -2282,7 +2282,7 @@ If every test needs to have certain meta keys.
 | :--------------------------------------------------------: | :-------------------------------------------------------: |
 |                          :x: Not                           |                      :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works

--- a/HOOKS.md
+++ b/HOOKS.md
@@ -83,6 +83,7 @@
 - [`dbt-compile`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#dbt-compile): Run `dbt compile` command.
 - [`dbt-deps`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#dbt-deps): Run `dbt deps` command.
 - [`dbt-docs-generate`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#dbt-docs-generate): Run `dbt docs generate` command.
+- [`dbt-parse`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#dbt-parse): Run `dbt parse` command.
 - [`dbt-run`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#dbt-run): Run `dbt run` command.
 - [`dbt-test`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#dbt-test): Run `dbt test` command.
 

--- a/HOOKS.md
+++ b/HOOKS.md
@@ -144,7 +144,7 @@ E.g. in two of your models, you have `customer_id` with the description `This is
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |   :x: Not needed since it also validates properties files   |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -189,7 +189,7 @@ You want to make sure your columns follow a contract, e.g. all your boolean colu
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                       :x: Not needed                        |                   :white_check_mark: Yes                   |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -230,7 +230,7 @@ You want to make sure that all specified columns in the properties files (usuall
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |   :x: Not needed since it also validates properties files   |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -278,7 +278,7 @@ You want to make sure that you have all the database columns listed in the prope
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                   :white_check_mark: Yes                   |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -324,7 +324,7 @@ You want to make sure that all models have a description.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |   :x: Not needed since it also validates properties files   |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -377,7 +377,7 @@ If every model needs to have certain meta keys.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |   :x: Not needed since it also validates properties files   |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -430,7 +430,7 @@ If every model needs to have certain labels keys.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |   :x: Not needed since it also validates properties files   |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -476,7 +476,7 @@ You want to make sure that every model has a properties file.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -525,7 +525,7 @@ You want to make sure that every model has certain tests.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -570,7 +570,7 @@ You want to make sure that every model has certain tests.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -616,7 +616,7 @@ You want to make sure that every model has one (or more) of a group of eligible 
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -661,7 +661,7 @@ You want to make sure that every model was tested.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -707,7 +707,7 @@ You want to make sure your model names follow a naming convention (e.g., staging
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                       :x: Not needed                        |                   :white_check_mark: Yes                   |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -754,7 +754,7 @@ You want to find orphaned models (empty file, hard-coded reference, etc.). Or yo
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -800,7 +800,7 @@ You want to be sure that certain models are using only models from specified dat
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -845,7 +845,7 @@ You want to be sure that certain models are using only models from specified sch
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -890,7 +890,7 @@ Make sure you did not typo in tags.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -931,7 +931,7 @@ Make sure to increase the efficiency within your dbt run and make use of good ma
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 ### `check-script-ref-and-source`
@@ -962,7 +962,7 @@ Make sure you have only valid ref and sources in your script and you do not want
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 ### `check-script-semicolon`
@@ -996,7 +996,7 @@ Make sure you did not provide a semicolon at the end of the file.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1034,7 +1034,7 @@ To make sure that you have only refs and sources in your `SQL` files.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                       :x: Not needed                        |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1068,7 +1068,7 @@ You want to make sure that all specified columns in the properties files (usuall
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                             :x:                             |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1108,7 +1108,7 @@ You want to make sure that you have all the database columns listed in the prope
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                           :x: No                            |                   :white_check_mark: Yes                   |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1148,7 +1148,7 @@ You want to make sure that all sources have a description.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                       :x: Not needed                        |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1186,7 +1186,7 @@ You want to make sure that all freshness is correctly set.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                       :x: Not needed                        |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1221,7 +1221,7 @@ You want to make sure that the source has loader specified.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                       :x: Not needed                        |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1263,7 +1263,7 @@ If every source needs to have certain meta keys.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |   :x: Not needed since it also validates properties files   |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1305,7 +1305,7 @@ If every source needs to have certain labels keys.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |   :x: Not needed since it also validates properties files   |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1347,7 +1347,7 @@ You want to make sure that every source has certain tests.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                           :x: Yes                           |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1389,7 +1389,7 @@ You want to make sure that every source has certain tests.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                           :x: Yes                           |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1431,7 +1431,7 @@ You want to make sure that every source was tested.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                           :x: Yes                           |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1474,7 +1474,7 @@ You want to make sure that every source has one (or more) of a group of eligible
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1516,7 +1516,7 @@ Make sure you did not typo in tags.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                       :x: Not needed                        |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1560,7 +1560,7 @@ You want to find orphaned sources without any dependencies. Or you want to make 
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1601,7 +1601,7 @@ You want to make sure that all macros have a description.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |   :x: Not needed since it also validates properties files   |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1647,7 +1647,7 @@ You want to make sure that all specified arguments in the properties files (usua
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |   :x: Not needed since it also validates properties files   |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1697,7 +1697,7 @@ You are too lazy to define schemas manually :D.
 | :-----------------------------------------------------------------------: | :--------------------------------------------------------: |
 | :x: Not needed since this hook tries to generate even non-existent source |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1754,7 +1754,7 @@ You want the descriptions of the same columns to be the same. E.g. in two of you
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |   :x: Not needed since this hook is using only yaml files   |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1800,7 +1800,7 @@ You are running and debugging your `SQL` in the editor. This editor does not kno
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1847,7 +1847,7 @@ You are running and debugging your `SQL` in the editor. This editor does not kno
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                          :x: Yes                           |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1888,7 +1888,7 @@ You are too lazy or forgetful to delete one character at the end of the script.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                       :x: Not needed                        |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -1981,6 +1981,40 @@ repos:
  hooks:
  - id: dbt-docs-generate
 ```
+
+---
+
+### `dbt-parse`
+
+Run the` dbt parse` command. Generates `manifest.json` from source model, test, and analysis files.
+
+#### Arguments
+
+`--global-flags`: Global dbt flags applicable to all subcommands. Instead of dash `-` please use `+`.</br>
+`--cmd-flags`: Command-specific dbt flags. Instead of dash `-` please use `+`.</br>
+
+#### Example
+
+```
+repos:
+- repo: https://github.com/dbt-checkpoint/dbt-checkpoint
+ rev: v1.0.0
+ hooks:
+ - id: dbt-parse
+```
+
+or
+
+```
+repos:
+- repo: https://github.com/dbt-checkpoint/dbt-checkpoint
+ rev: v1.0.0
+ hooks:
+ - id: dbt-parse
+   args: ["--cmd-flags", "++profiles-dir", ".", "++project-dir", ".", "--"]
+```
+
+:warning: do not forget to include `--` as the last argument. Otherwise `pre-commit` would not be able to separate a list of files with args.
 
 ---
 
@@ -2095,7 +2129,7 @@ If every macro needs to have certain meta keys.
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
 |                   :white_check_mark: Yes                    |                       :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -2146,7 +2180,7 @@ If every seed needs to have certain meta keys.
 | :--------------------------------------------------------: | :-------------------------------------------------------: |
 |                   :white_check_mark: Yes                   |                      :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -2197,7 +2231,7 @@ If every snapshot needs to have certain meta keys.
 | :------------------------------------------------------------: | :-----------------------------------------------------------: |
 |                            :x: Not                             |                        :x: Not needed                         |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works
@@ -2248,7 +2282,7 @@ If every test needs to have certain meta keys.
 | :--------------------------------------------------------: | :-------------------------------------------------------: |
 |                          :x: Not                           |                      :x: Not needed                       |
 
-<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook.<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
 
 #### How it works

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Since the root-level `exclude` statement is handled by pre-commit, when those ho
 - [`dbt-compile`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#dbt-compile): Run `dbt compile` command.
 - [`dbt-deps`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#dbt-deps): Run `dbt deps` command.
 - [`dbt-docs-generate`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#dbt-docs-generate): Run `dbt docs generate` command.
+- [`dbt-parse`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#dbt-parse): Run `dbt parse` command.
 - [`dbt-run`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#dbt-run): Run `dbt run` command.
 - [`dbt-test`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#dbt-test): Run `dbt test` command.
 
@@ -181,8 +182,8 @@ repos:
 
 Unfortunately, you cannot natively use `dbt-checkpoint` if you are using **dbt Cloud**. But you can run checks after you push changes into Github.
 
-`dbt-checkpoint` for the most of the hooks needs `manifest.json` (see requirements section in hook documentation), that is in the `target` folder. Since this target folder is usually in `.gitignore`, you need to generate it. For that you need to run `dbt-compile` (or `dbt-run`) command.
-To be able to compile dbt, you also need [profiles.yml](https://docs.getdbt.com/dbt-cli/configure-your-profile) file with your credentials. **To provide passwords and secrets use Github Secrets** (see example).
+`dbt-checkpoint` for the most of the hooks needs `manifest.json` (see requirements section in hook documentation), that is in the `target` folder. Since this target folder is usually in `.gitignore`, you need to generate it. For that you need to run `dbt-run` (or `dbt-compile` or `dbt-run`) command.
+To be able to parse dbt, you also need [profiles.yml](https://docs.getdbt.com/dbt-cli/configure-your-profile) file with your credentials. **To provide passwords and secrets use Github Secrets** (see example).
 
 Say you want to check that a model contains at least two tests, you would use this configuration:
 
@@ -202,8 +203,7 @@ repos:
 - repo: https://github.com/dbt-checkpoint/dbt-checkpoint
  rev: v1.2.1
  hooks:
- - id: dbt-compile
-   args: ["--cmd-flags", "++profiles-dir", "."]
+ - id: dbt-parse
  - id: check-model-has-tests
    args: ["--test-cnt", "2", "--"]
 ```

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ repos:
 
 Unfortunately, you cannot natively use `dbt-checkpoint` if you are using **dbt Cloud**. But you can run checks after you push changes into Github.
 
-`dbt-checkpoint` for the most of the hooks needs `manifest.json` (see requirements section in hook documentation), that is in the `target` folder. Since this target folder is usually in `.gitignore`, you need to generate it. For that you need to run `dbt-run` (or `dbt-compile` or `dbt-run`) command.
+`dbt-checkpoint` for the most of the hooks needs `manifest.json` (see requirements section in hook documentation), that is in the `target` folder. Since this target folder is usually in `.gitignore`, you need to generate it. For that you need to run the `dbt-parse` command.
 To be able to parse dbt, you also need [profiles.yml](https://docs.getdbt.com/dbt-cli/configure-your-profile) file with your credentials. **To provide passwords and secrets use Github Secrets** (see example).
 
 Say you want to check that a model contains at least two tests, you would use this configuration:

--- a/dbt_checkpoint/dbt_parse.py
+++ b/dbt_checkpoint/dbt_parse.py
@@ -1,37 +1,28 @@
 import argparse
-import os
-import time
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Sequence
 
-from dbt_checkpoint.utils import (
-    add_config_args,
-    add_dbt_cmd_args,
-    add_dbt_cmd_model_args,
-    add_filenames_args,
-    extend_dbt_project_dir_flag,
-    get_config_file,
-    get_flags,
-    paths_to_dbt_models,
-    run_dbt_cmd,
-)
+from dbt_checkpoint.utils import add_config_args
+from dbt_checkpoint.utils import add_dbt_cmd_args
+from dbt_checkpoint.utils import add_dbt_cmd_model_args
+from dbt_checkpoint.utils import add_filenames_args
+from dbt_checkpoint.utils import extend_dbt_project_dir_flag
+from dbt_checkpoint.utils import get_config_file
+from dbt_checkpoint.utils import get_flags
+from dbt_checkpoint.utils import run_dbt_cmd
 
 
 def prepare_cmd(
-    paths: Sequence[str],
     global_flags: Optional[Sequence[str]] = None,
     cmd_flags: Optional[Sequence[str]] = None,
-    prefix: str = "",
-    postfix: str = "",
-    models: Optional[Sequence[str]] = None,
     config: Dict[str, Any] = {},
 ) -> List[str]:
     global_flags = get_flags(global_flags)
     cmd_flags = get_flags(cmd_flags)
     dbt_project_dir = config.get("dbt-project-dir")
-    if models:
-        dbt_models = models
-    else:
-        dbt_models = paths_to_dbt_models(paths, prefix, postfix)
     cmd = ["dbt", *global_flags, "parse", *cmd_flags]
     return extend_dbt_project_dir_flag(cmd, cmd_flags, dbt_project_dir)
 
@@ -46,15 +37,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     args = parser.parse_args(argv)
     config = get_config_file(args.config)
 
-    cmd = prepare_cmd(
-        args.filenames,
-        args.global_flags,
-        args.cmd_flags,
-        args.model_prefix,
-        args.model_postfix,
-        args.models,
-        config
-    )
+    cmd = prepare_cmd(args.global_flags, args.cmd_flags, config)
     return run_dbt_cmd(cmd)
 
 

--- a/dbt_checkpoint/dbt_parse.py
+++ b/dbt_checkpoint/dbt_parse.py
@@ -1,0 +1,62 @@
+import argparse
+import os
+import time
+from typing import Any, Dict, List, Optional, Sequence
+
+from dbt_checkpoint.utils import (
+    add_config_args,
+    add_dbt_cmd_args,
+    add_dbt_cmd_model_args,
+    add_filenames_args,
+    extend_dbt_project_dir_flag,
+    get_config_file,
+    get_flags,
+    paths_to_dbt_models,
+    run_dbt_cmd,
+)
+
+
+def prepare_cmd(
+    paths: Sequence[str],
+    global_flags: Optional[Sequence[str]] = None,
+    cmd_flags: Optional[Sequence[str]] = None,
+    prefix: str = "",
+    postfix: str = "",
+    models: Optional[Sequence[str]] = None,
+    config: Dict[str, Any] = {},
+) -> List[str]:
+    global_flags = get_flags(global_flags)
+    cmd_flags = get_flags(cmd_flags)
+    dbt_project_dir = config.get("dbt-project-dir")
+    if models:
+        dbt_models = models
+    else:
+        dbt_models = paths_to_dbt_models(paths, prefix, postfix)
+    cmd = ["dbt", *global_flags, "parse", *cmd_flags]
+    return extend_dbt_project_dir_flag(cmd, cmd_flags, dbt_project_dir)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser()
+    add_filenames_args(parser)
+    add_dbt_cmd_args(parser)
+    add_dbt_cmd_model_args(parser)
+    add_config_args(parser)
+
+    args = parser.parse_args(argv)
+    config = get_config_file(args.config)
+
+    cmd = prepare_cmd(
+        args.filenames,
+        args.global_flags,
+        args.cmd_flags,
+        args.model_prefix,
+        args.model_postfix,
+        args.models,
+        config
+    )
+    return run_dbt_cmd(cmd)
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,6 +67,7 @@ console_scripts =
     dbt-compile = dbt_checkpoint.dbt_compile:main
     dbt-deps = dbt_checkpoint.dbt_deps:main
     dbt-docs-generate = dbt_checkpoint.dbt_docs_generate:main
+    dbt-parse = dbt_checkpoint.dbt_parse:main
     dbt-run = dbt_checkpoint.dbt_run:main
     dbt-test = dbt_checkpoint.dbt_test:main
     generate-missing-sources = dbt_checkpoint.generate_missing_sources:main

--- a/tests/unit/test_dbt_parse.py
+++ b/tests/unit/test_dbt_parse.py
@@ -1,0 +1,65 @@
+from unittest.mock import patch
+
+import pytest
+
+from dbt_checkpoint.dbt_parse import main
+from dbt_checkpoint.dbt_parse import prepare_cmd
+
+
+def test_dbt_parse():
+    with patch("dbt_checkpoint.utils.subprocess.Popen") as mock_popen:
+        mock_popen.return_value.communicate.return_value = (
+            b"stdout",
+            b"stderr",
+        )
+        mock_popen.return_value.returncode = 0
+        result = main(("test",))
+        assert result == 0
+
+
+def test_dbt_parse_error():
+    with patch("dbt_checkpoint.utils.subprocess.Popen") as mock_popen:
+        mock_popen.return_value.communicate.return_value = (
+            b"stdout",
+            "stderr",
+        )
+        mock_popen.return_value.returncode = 1
+        result = main(("test",))
+        assert result == 1
+
+
+@pytest.mark.parametrize(
+    "files,global_flags,cmd_flags,models,expected",
+    [
+        (["/aa/bb/cc.txt"], None, None, None, ["dbt", "parse"]),
+        (
+            ["/aa/bb/cc.txt"],
+            ["++debug", "++no-write-json"],
+            None,
+            None,
+            [
+                "dbt",
+                "--debug",
+                "--no-write-json",
+                "parse",
+            ],
+        ),
+        (
+            ["/aa/bb/cc.txt"],
+            None,
+            ["+t", "prod"],
+            None,
+            ["dbt", "parse", "-t", "prod"],
+        ),
+        (
+            ["/aa/bb/cc.txt"],
+            "",
+            ["+t", "prod"],
+            None,
+            ["dbt", "parse", "-t", "prod"],
+        ),
+    ],
+)
+def test_dbt_parse_cmd(files, global_flags, cmd_flags, models, expected):
+    result = prepare_cmd(files, global_flags, cmd_flags, models=models)
+    assert result == expected

--- a/tests/unit/test_dbt_parse.py
+++ b/tests/unit/test_dbt_parse.py
@@ -29,13 +29,11 @@ def test_dbt_parse_error():
 
 
 @pytest.mark.parametrize(
-    "files,global_flags,cmd_flags,models,expected",
+    "global_flags,cmd_flags,expected",
     [
-        (["/aa/bb/cc.txt"], None, None, None, ["dbt", "parse"]),
+        (None, None, ["dbt", "parse"]),
         (
-            ["/aa/bb/cc.txt"],
             ["++debug", "++no-write-json"],
-            None,
             None,
             [
                 "dbt",
@@ -45,21 +43,17 @@ def test_dbt_parse_error():
             ],
         ),
         (
-            ["/aa/bb/cc.txt"],
             None,
             ["+t", "prod"],
-            None,
             ["dbt", "parse", "-t", "prod"],
         ),
         (
-            ["/aa/bb/cc.txt"],
             "",
             ["+t", "prod"],
-            None,
             ["dbt", "parse", "-t", "prod"],
         ),
     ],
 )
-def test_dbt_parse_cmd(files, global_flags, cmd_flags, models, expected):
-    result = prepare_cmd(files, global_flags, cmd_flags, models=models)
+def test_dbt_parse_cmd(global_flags, cmd_flags, expected):
+    result = prepare_cmd(global_flags, cmd_flags)
     assert result == expected


### PR DESCRIPTION
Addresses #166.

I really like what `dbt-checkpoint` offers and want to use it on most of the dbt projects I work with. One downside is that it needs to run `dbt compile` for a lot of hooks and this requires a connection to the underlying database. This can be rather painful as a lot of my recent clients are using dbt Cloud and when we try to enable `dbt-checkpoint` through an Azure DevOps pipeline or GitHub workflow then we need to add authentication from the version control provider to the database, this is a barrier for a lot of clients and a hard blocker for some. This PR adds a `dbt-parse` hook that generates a `manifest.json` but doesn't require a database connection.

To do:
* Re-evaluate what hooks can be updated to only require `dbt-parse` and not `dbt-compile`.
* Add tests.