### PR TITLE
Bugfix-153: Added seeds and snapshots as parent node_types

### DIFF
--- a/dbt_checkpoint/check_model_parents_and_childs.py
+++ b/dbt_checkpoint/check_model_parents_and_childs.py
@@ -42,7 +42,7 @@ def check_child_parent_cnt(
                 manifest=manifest,
                 obj=model,
                 manifest_node="parent_map",
-                node_types=["model", "source"],
+                node_types=["model", "source", "seed", "snapshot"],
             )
         )
         real_cnt = {"childs": len(childs), "parents": len(parents)}

--- a/dbt_checkpoint/check_model_parents_schema.py
+++ b/dbt_checkpoint/check_model_parents_schema.py
@@ -36,7 +36,7 @@ def check_parents_schema(
                 manifest=manifest,
                 obj=model,
                 manifest_node="parent_map",
-                node_types=["model", "source"],
+                node_types=["model", "source", "seed", "snapshot"],
             )
         )
         for parent in parents:

--- a/dbt_checkpoint/utils.py
+++ b/dbt_checkpoint/utils.py
@@ -1,6 +1,5 @@
 import argparse
 import json
-from random import seed
 import re
 import subprocess
 from dataclasses import dataclass

--- a/dbt_checkpoint/utils.py
+++ b/dbt_checkpoint/utils.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+from random import seed
 import re
 import subprocess
 from dataclasses import dataclass
@@ -56,6 +57,19 @@ class Source:
     filename: str
     node: Dict[str, Any]
 
+@dataclass
+class Seed:
+    seed_id: str
+    seed_name: str
+    filename: str
+    node: Dict[str, Any]
+
+@dataclass
+class Snapshot:
+    snapshot_id: str
+    snapshot_name: str
+    filename: str
+    node: Dict[str, Any]
 
 @dataclass
 class ModelSchema:
@@ -408,6 +422,22 @@ def get_parent_childs(
                         yield Model(
                             model_id=node_id,
                             model_name=node.get("name", ""),  # pragma: no mutate
+                            filename=node.get("path", ""),  # pragma: no mutate
+                            node=node,
+                        )
+                    elif node_type == "seed":  # Add this block
+                        node = manifest.get("seeds", {}).get(node_id)
+                        yield Seed(
+                            seed_id=node_id,
+                            seed_name=node.get("name", ""),  # pragma: no mutate
+                            filename=node.get("path", ""),  # pragma: no mutate
+                            node=node,
+                        )
+                    elif node_type == "snapshot":  # Add this block
+                        node = manifest.get("snapshots", {}).get(node_id)
+                        yield Snapshot(
+                            snapshot_id=node_id,
+                            snapshot_name=node.get("name", ""),  # pragma: no mutate
                             filename=node.get("path", ""),  # pragma: no mutate
                             node=node,
                         )


### PR DESCRIPTION
This PR is a response to the bug #153 and introduces the following:

- Added seeds & snapshots to parent node_types in `check_model_parents_and_childs.py` &  `check_model_parents_schema.py`
- Added seeds and snapshots to `get_parent_childs` function