### PR TITLE
Documentation Update: Changed Hooks to reflect correct usage of args for source-has-tests

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -1405,7 +1405,7 @@ Ensures that the source has a number of tests.
 
 #### Arguments
 
-`--tests`: Minimum number of tests required.
+`--test-cnt`: Minimum number of tests required.
 
 #### Example
 
@@ -1415,7 +1415,7 @@ repos:
  rev: v1.0.0
  hooks:
  - id: check-source-has-tests
-   args: ["--tests", "2", "--"]
+   args: ["--test-cnt", "2", "--"]
 ```
 
 :warning: do not forget to include `--` as the last argument. Otherwise `pre-commit` would not be able to separate a list of files with args.


### PR DESCRIPTION
Fixes #201 

Updated `HOOKS.md`

For id source-has-tests
- Changed argument `--tests` to `--test-cnt` to reflect correct usage
