### PR TITLE
Expand testing to python 3.10 - 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,9 @@ jobs:
           - "ubuntu-py37"
           - "ubuntu-py38"
           - "ubuntu-py39"
+          - "ubuntu-py310"
+          - "ubuntu-py311"
+          - "ubuntu-py312"
         include:
           - name: "ubuntu-py37"
             python: "3.7"
@@ -31,6 +34,18 @@ jobs:
             python: "3.9"
             os: ubuntu-latest
             tox_env: "py39"
+          - name: "ubuntu-py310"
+            python: "3.10"
+            os: ubuntu-latest
+            tox_env: "py310"
+          - name: "ubuntu-py311"
+            python: "3.11"
+            os: ubuntu-latest
+            tox_env: "py311"
+          - name: "ubuntu-py312"
+            python: "3.12"
+            os: ubuntu-latest
+            tox_env: "py312"
 
     steps:
       - uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39},pypy3,pre-commit
+envlist = py{37,38,39,310,311,312},pypy3,pre-commit
 minversion = 3.14.2
 requires =
     virtualenv >= 16.7.9


### PR DESCRIPTION
Currently `tox` only runs for python up to 3.9. This PR expands support to python 3.10, 3.11 and 3.12 to provide a more comprehensive testing suite.