### PR TITLE
All hook names <= 50 characters

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -65,7 +65,7 @@
   language: python
   types_or: [sql, yaml]
 - id: check-model-has-tests-by-group
-  name: Check the model has a number of tests from a group of tests.
+  name: Check model; number of tests from group of tests.
   description: Ensures that the model has a number of tests from a group of tests.
   entry: check-model-has-tests-by-group
   language: python
@@ -95,12 +95,12 @@
   language: python
   types_or: [sql]
 - id: check-model-parents-schema
-  name: Check parent models or sources are from certain schema
+  name: Check parent models/sources from certain schema
   entry: check-model-parents-schema
   language: python
   types_or: [yaml, sql]
 - id: check-model-parents-database
-  name: Check parent models or sources are from certain database
+  name: Check parent models/sources from certain database
   entry: check-model-parents-database
   language: python
   types_or: [sql, yaml]
@@ -135,7 +135,7 @@
   language: python
   types_or: [sql]
 - id: check-source-childs
-  name: Check the source has a specific number (max/min) of childs.
+  name: Check the source has max/min number of childs.
   description: Ensures the source has a specific number (max/min) of childs.
   entry: check-source-childs
   language: python
@@ -147,7 +147,7 @@
   language: python
   types_or: [yaml]
 - id: check-source-has-all-columns
-  name: Check the source has all columns in the properties file
+  name: Check source has all columns in properties file
   description: Ensures that all columns in the database are specified in the properties file.
   entry: check-source-has-all-columns
   language: python

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -514,3 +514,9 @@ def temp_git_dir(tmpdir):
     git_dir = tmpdir.join("gits")
     cmd_output("git", "init", "--", str(git_dir))
     yield git_dir
+
+
+@pytest.fixture(scope="module")
+def pre_commit_hooks_yaml_dict():
+    with open(".pre-commit-hooks.yaml") as f:
+        yield yaml.safe_load(f)

--- a/tests/unit/test_pre_commit_hooks_yaml.py
+++ b/tests/unit/test_pre_commit_hooks_yaml.py
@@ -1,0 +1,12 @@
+import pytest
+
+
+def test_hook_name_length_less_le_50_chars(pre_commit_hooks_yaml_dict):
+    """
+    Pre-commit wants all hook names to be <= 50 characters.
+    See here for more info: https://github.com/pre-commit/pre-commit.com/pull/901
+    """
+
+    for hook in pre_commit_hooks_yaml_dict:
+        if len(hook["name"]) > 50:
+            pytest.fail(f"Hook name '{hook['name']}' is longer than 50 characters")


### PR DESCRIPTION
Addresses #164 by changing all hook names to be <= 50 characters. Also added a pytest to help with enforcing this.