### PR TITLE
Issue 219: extend check_model_has_tests_by_name exclude argument to committed files

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -109,7 +109,7 @@ Hooks that use `--exclude` in their args, should receive it this way:
 ```
 - id: check-model-has-tests
   description: "Ensures that the model has a number of tests"
-  args: ["--test-cnt", "1", "--exclude models/demo", "--"]
+  args: ["--test-cnt", "1", "--exclude", "models/demo", "--"]
 ```
 
 :exclamation:**If you have an idea for a new hook or you found a bug, [let us know](https://github.com/dbt-checkpoint/dbt-checkpoint/issues/new)**:exclamation:

--- a/dbt_checkpoint/check_model_has_tests_by_name.py
+++ b/dbt_checkpoint/check_model_has_tests_by_name.py
@@ -3,6 +3,7 @@ import os
 import time
 from itertools import groupby
 from typing import Any, Dict, Optional, Sequence
+import re
 
 from dbt_checkpoint.tracking import dbtCheckpointTracking
 from dbt_checkpoint.utils import (
@@ -25,6 +26,13 @@ def check_test_cnt(
     exclude_pattern: str,
     include_disabled: bool = False,
 ) -> int:
+    exclude_re = re.compile(exclude_pattern)
+    paths = [
+        filename
+        for filename in paths
+        if not exclude_re.search(filename)
+    ]
+
     paths = get_missing_file_paths(
         paths, manifest, extensions=[".sql"], exclude_pattern=exclude_pattern
     )

--- a/dbt_checkpoint/check_model_has_tests_by_name.py
+++ b/dbt_checkpoint/check_model_has_tests_by_name.py
@@ -1,22 +1,23 @@
 import argparse
 import os
+import re
 import time
 from itertools import groupby
-from typing import Any, Dict, Optional, Sequence
-import re
+from typing import Any
+from typing import Dict
+from typing import Optional
+from typing import Sequence
 
 from dbt_checkpoint.tracking import dbtCheckpointTracking
-from dbt_checkpoint.utils import (
-    JsonOpenError,
-    ParseDict,
-    Test,
-    add_default_args,
-    get_dbt_manifest,
-    get_missing_file_paths,
-    get_model_sqls,
-    get_models,
-    get_parent_childs,
-)
+from dbt_checkpoint.utils import add_default_args
+from dbt_checkpoint.utils import get_dbt_manifest
+from dbt_checkpoint.utils import get_missing_file_paths
+from dbt_checkpoint.utils import get_model_sqls
+from dbt_checkpoint.utils import get_models
+from dbt_checkpoint.utils import get_parent_childs
+from dbt_checkpoint.utils import JsonOpenError
+from dbt_checkpoint.utils import ParseDict
+from dbt_checkpoint.utils import Test
 
 
 def check_test_cnt(
@@ -27,11 +28,7 @@ def check_test_cnt(
     include_disabled: bool = False,
 ) -> int:
     exclude_re = re.compile(exclude_pattern)
-    paths = [
-        filename
-        for filename in paths
-        if not exclude_re.search(filename)
-    ]
+    paths = [filename for filename in paths if not exclude_re.search(filename)]
 
     paths = get_missing_file_paths(
         paths, manifest, extensions=[".sql"], exclude_pattern=exclude_pattern


### PR DESCRIPTION
Description:
- Two files changed:
  - HOOKS.md: update the example of the exclude argument
  - check_model_has_tests_by_name.py:  applies exclude argument to the the files being committed

Description of the issue can be found in [issue 219](https://github.com/dbt-checkpoint/dbt-checkpoint/issues/219)