### PR TITLE
Implement the `check-selectors-duplicate-names` hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -343,3 +343,10 @@
   entry: check-test-has-meta-keys
   language: python
   types_or: [sql]
+- id: check-selectors-duplicate-names
+  name: Check selectors for duplicate names
+  description: Ensures that there are no duplicate selector names in `selectors.yml`
+  entry: check-selectors-duplicate-names
+  language: python
+  types_or: [yaml]
+  files: 'selectors.yml'

--- a/HOOKS.md
+++ b/HOOKS.md
@@ -71,6 +71,10 @@
 
 - [`check-test-has-meta-keys`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-test-has-meta-keys): Check singular tests have meta keys
 
+**Selectors checks:**
+
+- [`check-selectors-duplicate-names`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-selectors-duplicate-names): Check for duplicate selector names in `selectors.yml`.
+
 **Modifiers:**
 
 - [`generate-missing-sources`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#generate-missing-sources): If any source is missing this hook tries to create it.
@@ -2375,3 +2379,35 @@ If every test needs to have certain meta keys.
 If you `run` your test and then you delete meta keys from a properties file, the hook success since the meta keys is still present in `manifest.json`.
 
 ---
+
+### `check-selectors-duplicate-names`
+
+Ensures that there are no duplicate selector names in your `selectors.yml` file.
+
+#### Arguments
+
+`--filenames`: List of YAML files to check for duplicate selector names.
+
+#### Example
+
+```
+repos:
+- repo: https://github.com/dbt-checkpoint/dbt-checkpoint
+ rev: v1.2.1
+ hooks:
+ - id: check-selectors-duplicate-names
+```
+
+#### When to use it
+
+You want to ensure that each selector name is unique within your `selectors.yml` file.
+
+#### How it works
+
+- Hook takes all specified YAML files.
+- Each file is parsed to check for duplicate selector names.
+- If any duplicate names are found, the hook fails and reports the duplicates.
+
+#### Known limitations
+
+This hook only checks for duplicate names within the provided files and does not validate the overall structure of `selectors.yml`.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ Since the root-level `exclude` statement is handled by pre-commit, when those ho
 - [`check-macro-has-description`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-macro-has-description): Check the macro has description.
 - [`check-macro-arguments-have-desc`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-macro-arguments-have-desc): Check the macro arguments have description.
 
+**Selectors checks:**
+
+- [`check-selectors-duplicate-names`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-selectors-duplicate-names): Check for duplicate names in selectors.
+
 **Modifiers:**
 
 - [`generate-missing-sources`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#generate-missing-sources): If any source is missing this hook tries to create it.

--- a/dbt_checkpoint/check_selectors_duplicate_names.py
+++ b/dbt_checkpoint/check_selectors_duplicate_names.py
@@ -1,0 +1,77 @@
+import argparse
+import os
+import time
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Sequence
+
+import yaml
+
+from dbt_checkpoint.tracking import dbtCheckpointTracking
+from dbt_checkpoint.utils import add_default_args
+
+
+def check_selectors_duplicate_names(data: Dict[str, Any]) -> List[str]:
+    errors = []
+    selector_names = set()
+    duplicates = set()
+
+    for selector in data.get("selectors", []):
+        name = selector.get("name")
+        if name in selector_names:
+            duplicates.add(name)
+        else:
+            selector_names.add(name)
+
+    if duplicates:
+        for name in duplicates:
+            errors.append(f"Duplicate selector name found: '{name}'")
+
+    return errors
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser()
+    add_default_args(parser)
+
+    args = parser.parse_args(argv)
+
+    error_flag = False
+    script_args = vars(args)
+
+    start_time = time.time()
+    for file_path in args.filenames:
+        try:
+            with open(file_path, "r") as file:
+                data = yaml.safe_load(file)
+                errors = check_selectors_duplicate_names(data)
+                if errors:
+                    print(f"Errors found in '{file_path}':")
+                    for error in errors:
+                        print(error)
+                    error_flag = True
+        except Exception as e:
+            print(f"Failed to process '{file_path}': {e}")
+            error_flag = True
+    end_time = time.time()
+
+    tracker = dbtCheckpointTracking(script_args=script_args)
+    tracker.track_hook_event(
+        event_name="Hook Executed",
+        manifest=None,
+        event_properties={
+            "hook_name": os.path.basename(__file__),
+            "description": "Check for duplicate selector names",
+            "status": 1 if error_flag else 0,
+            "execution_time": end_time - start_time,
+            "is_pytest": script_args.get("is_test"),
+        },
+    )
+
+    return 1 if error_flag else 0
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/tests/unit/test_check_selectors_duplicate_names.py
+++ b/tests/unit/test_check_selectors_duplicate_names.py
@@ -1,0 +1,52 @@
+import pytest
+import yaml
+
+from dbt_checkpoint.check_selectors_duplicate_names import (
+    check_selectors_duplicate_names,
+)
+
+# Test cases: input data, expected errors
+TESTS = [
+    (
+        {"selectors": [{"name": "selector1"}, {"name": "selector2"}]},
+        [],
+    ),
+    (
+        {"selectors": [{"name": "selector1"}, {"name": "selector1"}]},
+        ["Duplicate selector name found: 'selector1'"],
+    ),
+    (
+        {
+            "selectors": [
+                {"name": "selector1"},
+                {"name": "selector2"},
+                {"name": "selector1"},
+            ]
+        },
+        ["Duplicate selector name found: 'selector1'"],
+    ),
+    (
+        {
+            "selectors": [
+                {"name": "selector1"},
+                {"name": "selector2"},
+                {"name": "selector2"},
+                {"name": "selector1"},
+            ]
+        },
+        [
+            "Duplicate selector name found: 'selector1'",
+            "Duplicate selector name found: 'selector2'",
+        ],
+    ),
+    (
+        {"selectors": []},
+        [],
+    ),
+]
+
+
+@pytest.mark.parametrize("input_data, expected_errors", TESTS)
+def test_check_selectors_duplicate_names(input_data, expected_errors):
+    errors = check_selectors_duplicate_names(input_data)
+    assert errors == expected_errors

--- a/tests/unit/test_check_selectors_duplicate_names.py
+++ b/tests/unit/test_check_selectors_duplicate_names.py
@@ -1,5 +1,4 @@
 import pytest
-import yaml
 
 from dbt_checkpoint.check_selectors_duplicate_names import (
     check_selectors_duplicate_names,
@@ -35,8 +34,8 @@ TESTS = [
             ]
         },
         [
-            "Duplicate selector name found: 'selector1'",
             "Duplicate selector name found: 'selector2'",
+            "Duplicate selector name found: 'selector1'",
         ],
     ),
     (
@@ -49,4 +48,4 @@ TESTS = [
 @pytest.mark.parametrize("input_data, expected_errors", TESTS)
 def test_check_selectors_duplicate_names(input_data, expected_errors):
     errors = check_selectors_duplicate_names(input_data)
-    assert errors == expected_errors
+    assert sorted(errors) == sorted(expected_errors)


### PR DESCRIPTION
## Overview

I want to implement a new hook to check if `selectors.yml` contains duplicate names or not.