### PR TITLE
check-script-ref-and-source support for versioned models

### DIFF
--- a/dbt_checkpoint/check_script_ref_and_source.py
+++ b/dbt_checkpoint/check_script_ref_and_source.py
@@ -32,7 +32,10 @@ def check_refs_sources(
             src_ref_value = src_ref[1].replace("'", "").replace('"', "").strip()
             if src_ref[0] == "ref":
                 ref_node = get_manifest_node_from_file_path(manifest, str(file))
-                for ref in ref_node.get("refs", []):
+                refs = ref_node.get("refs", [])
+                if not refs:
+                    models.add(src_ref_value)
+                for ref in refs:
                     ref_id = f"model.{ref.get('package') or ref_node['package_name']}.{ref.get('name')}"
                     if ref.get("version"):
                         ref_id += f".v{ref.get('version')}"

--- a/dbt_checkpoint/check_script_ref_and_source.py
+++ b/dbt_checkpoint/check_script_ref_and_source.py
@@ -4,6 +4,7 @@ import re
 import time
 from typing import Any, Dict, Optional, Sequence
 
+from dbt_checkpoint.check_script_has_no_table_name import replace_comments
 from dbt_checkpoint.tracking import dbtCheckpointTracking
 from dbt_checkpoint.utils import (
     JsonOpenError,
@@ -25,6 +26,7 @@ def check_refs_sources(
     sources = {}
     for _, file in sqls.items():
         full_script = file.read_text(encoding="utf-8")
+        full_script = replace_comments(full_script)
         src_refs = re.findall(r"\{\{\s*(source|ref)\s*\((.*)\)\s*\}\}", full_script)
         for src_ref in src_refs:
             src_ref_value = src_ref[1].replace("'", "").replace('"', "").strip()

--- a/dbt_checkpoint/check_script_ref_and_source.py
+++ b/dbt_checkpoint/check_script_ref_and_source.py
@@ -53,9 +53,12 @@ def check_refs_sources(
     if models:
         nodes = manifest.get("nodes", {})
         for _, value in nodes.items():
+            model_name = value.get("name")
             model_id = value.get("unique_id")
             if model_id in models:
                 models.remove(model_id)
+            elif model_name in models:
+                models.remove(model_name)
 
     if sources:
         srcs = manifest.get("sources", {})

--- a/dbt_checkpoint/check_script_ref_and_source.py
+++ b/dbt_checkpoint/check_script_ref_and_source.py
@@ -30,7 +30,7 @@ def check_refs_sources(
             src_ref_value = src_ref[1].replace("'", "").replace('"', "").strip()
             if src_ref[0] == "ref":
                 ref_node = get_manifest_node_from_file_path(manifest, str(file))
-                for ref in ref_node.get("refs"):
+                for ref in ref_node.get("refs", []):
                     ref_id = f"model.{ref.get('package') or ref_node['package_name']}.{ref.get('name')}"
                     if ref.get("version"):
                         ref_id += f".v{ref.get('version')}"

--- a/dbt_checkpoint/utils.py
+++ b/dbt_checkpoint/utils.py
@@ -461,6 +461,15 @@ def run_dbt_cmd(cmd: Sequence[Any]) -> int:
     return status_code
 
 
+def get_manifest_node_from_file_path(
+    manifest: Dict[str, Any], file_path: str
+) -> Dict[str, Any]:
+    for node in manifest.get("nodes", {}).values():
+        if node.get("original_file_path") == file_path:
+            return node
+    return {}
+
+
 def add_filenames_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "filenames",


### PR DESCRIPTION
This PR fixes #214 #194 

Now `check script ref and source` support versioned model refs.