### PR TITLE
Hotfix 2.0.4: manifest node discovery based on filepaths

### DIFF
--- a/dbt_checkpoint/check_database_casing_consistency.py
+++ b/dbt_checkpoint/check_database_casing_consistency.py
@@ -8,6 +8,7 @@ from dbt_checkpoint.utils import (
     get_dbt_catalog,
     get_dbt_manifest,
     red,
+    strings_differ_in_case,
 )
 
 
@@ -19,14 +20,17 @@ def _find_inconsistent_objects(
 ):
     for object in objects:
         result = {}
-        if manifest_objects[object].get("database") != catalog_objects[object].get(
-            "metadata", {}
-        ).get("database"):
+        if strings_differ_in_case(
+            manifest_objects[object].get("database", ""),
+            catalog_objects[object].get("metadata", {}).get("database", ""),
+        ):
             result["manifest"] = manifest_objects[object].get("database")
             result["catalog"] = catalog_objects[object].get("metadata").get("database")
-        if manifest_objects[object].get("schema") != catalog_objects[object].get(
-            "metadata", {}
-        ).get("schema"):
+
+        if strings_differ_in_case(
+            manifest_objects[object].get("schema", ""),
+            catalog_objects[object].get("metadata", {}).get("schema", ""),
+        ):
             result["manifest"] = (
                 f"{manifest_objects[object].get('database')}.{manifest_objects[object].get('schema')}"
             )

--- a/dbt_checkpoint/utils.py
+++ b/dbt_checkpoint/utils.py
@@ -465,7 +465,7 @@ def get_manifest_node_from_file_path(
     manifest: Dict[str, Any], file_path: str
 ) -> Dict[str, Any]:
     for node in manifest.get("nodes", {}).values():
-        if node.get("original_file_path") in file_path:
+        if node.get("original_file_path", "") in file_path:
             return node
     return {}
 

--- a/dbt_checkpoint/utils.py
+++ b/dbt_checkpoint/utils.py
@@ -465,7 +465,7 @@ def get_manifest_node_from_file_path(
     manifest: Dict[str, Any], file_path: str
 ) -> Dict[str, Any]:
     for node in manifest.get("nodes", {}).values():
-        if node.get("original_file_path") == file_path:
+        if node.get("original_file_path") in file_path:
             return node
     return {}
 
@@ -835,3 +835,7 @@ def validate_meta_keys(
         )
         return 1
     return 0
+
+
+def strings_differ_in_case(str1: str, str2: str) -> bool:
+    return str1.lower() == str2.lower() and str1 != str2

--- a/tests/unit/test_check_database_casing_consistency.py
+++ b/tests/unit/test_check_database_casing_consistency.py
@@ -64,7 +64,7 @@ def test_find_inconsistent_objects(manifest, catalog):
     )
     assert len(results) == 0
 
-    catalog["nodes"]["model.test_model"]["metadata"]["database"] = "DBT"
+    catalog["nodes"]["model.test_model"]["metadata"]["database"] = "TeSt"
     _find_inconsistent_objects(
         manifest["nodes"], catalog["nodes"], ["model.test_model"], results
     )
@@ -75,7 +75,7 @@ def test_check_database_casing_consistency(manifest, catalog):
     result = check_database_casing_consistency(manifest, catalog)
     assert result == 0
 
-    catalog["nodes"]["model.test_model"]["metadata"]["database"] = "DBT"
+    catalog["nodes"]["model.test_model"]["metadata"]["database"] = "TeSt"
     result = check_database_casing_consistency(manifest, catalog)
     assert result == 1
 


### PR DESCRIPTION
v2.0.4 Hotfix:
- Improve Manifest node discovery on filepath based
- Improve casing consistency hook, dbs can differ, not their casing