### PR TITLE
Fix #260: Add `check-model-parents-name-prefix` to `setup.cfg` and fix docs

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -911,8 +911,8 @@ repos:
 - repo: https://github.com/dbt-checkpoint/dbt-checkpoint
  rev: v1.0.0
  hooks:
- - id: check-model-parents-filename-prefix
-   exlude: ^models/stage/
+ - id: check-model-parents-name-prefix
+   exclude: ^models/stage/
    args: ["--whitelist", "stage_", "--"]
 ```
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ console_scripts =
     check-model-name-contract = dbt_checkpoint.check_model_name_contract:main
     check-model-parents-and-childs = dbt_checkpoint.check_model_parents_and_childs:main
     check-model-parents-database = dbt_checkpoint.check_model_parents_database:main
+    check-model-parents-name-prefix = dbt_checkpoint.check_model_parents_name_prefix:main
     check-model-parents-schema = dbt_checkpoint.check_model_parents_schema:main
     check-model-tags = dbt_checkpoint.check_model_tags:main
     check-script-has-no-table-name = dbt_checkpoint.check_script_has_no_table_name:main


### PR DESCRIPTION
This PR:
- Adds `check-model-parents-name-prefix` hook to `setup.cfg` file
- Fixes the docs for the hook
- 
Description of the issue can be found in #260 