### PR TITLE
Deprecate Python 3.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,17 +15,12 @@ jobs:
       fail-fast: false
       matrix:
         name:
-          - "ubuntu-py37"
           - "ubuntu-py38"
           - "ubuntu-py39"
           - "ubuntu-py310"
           - "ubuntu-py311"
           - "ubuntu-py312"
         include:
-          - name: "ubuntu-py37"
-            python: "3.7"
-            os: ubuntu-latest
-            tox_env: "py37"
           - name: "ubuntu-py38"
             python: "3.8"
             os: ubuntu-latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,9 +13,11 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: PyPy
 
 [options]
@@ -23,7 +25,7 @@ packages = find:
 install_requires =
     mixpanel
     pyyaml
-python_requires = >=3.7.1
+python_requires = >=3.8.1
 
 [options.entry_points]
 console_scripts =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311,312},pypy3,pre-commit
+envlist = py{38,39,310,311,312},pypy3,pre-commit
 minversion = 3.14.2
 requires =
     virtualenv >= 16.7.9


### PR DESCRIPTION
Python 3.7 has reached it's EOL support: https://devguide.python.org/versions/#status-of-python-versions

Also, it's no longer part of Github's [`setup-python` Action](https://github.com/actions/setup-python/issues/962)

To maintain ubuntu-latest support, we are removing dbt-checkpoint support for Python 3.7