### PR TITLE
check-model-name-contract can use manifest.json

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -786,7 +786,7 @@ You want to make sure your model names follow a naming convention (e.g., staging
 
 | Model exists in `manifest.json` <sup id="a1">[1](#f1)</sup> | Model exists in `catalog.json` <sup id="a2">[2](#f2)</sup> |
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
-|                       :x: Not needed                        |                   :white_check_mark: Yes                   |
+|                       :white_check_mark: Yes                |                        :x: Not needed                      |
 
 <sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.

--- a/dbt_checkpoint/check_model_name_contract.py
+++ b/dbt_checkpoint/check_model_name_contract.py
@@ -2,25 +2,23 @@ import argparse
 import os
 import re
 import time
-from typing import Any, Dict, Optional, Sequence
+from typing import Any
+from typing import Dict
+from typing import Optional
+from typing import Sequence
 
 from dbt_checkpoint.tracking import dbtCheckpointTracking
-from dbt_checkpoint.utils import (
-    JsonOpenError,
-    add_catalog_args,
-    add_default_args,
-    get_dbt_catalog,
-    get_dbt_manifest,
-    get_filenames,
-    get_missing_file_paths,
-    get_models,
-)
+from dbt_checkpoint.utils import add_default_args
+from dbt_checkpoint.utils import get_dbt_manifest
+from dbt_checkpoint.utils import get_filenames
+from dbt_checkpoint.utils import get_missing_file_paths
+from dbt_checkpoint.utils import get_models
+from dbt_checkpoint.utils import JsonOpenError
 
 
 def check_model_name_contract(
     paths: Sequence[str],
     pattern: str,
-    catalog: Dict[str, Any],
     manifest: Dict[str, Any],
     exclude_pattern: str,
     include_disabled: bool = False,
@@ -31,7 +29,7 @@ def check_model_name_contract(
     status_code = 0
     sqls = get_filenames(paths, [".sql"])
     filenames = set(sqls.keys())
-    models = get_models(catalog, filenames, include_disabled=include_disabled)
+    models = get_models(manifest, filenames, include_disabled=include_disabled)
 
     for model in models:
         model_name = model.filename
@@ -45,7 +43,6 @@ def check_model_name_contract(
 def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser()
     add_default_args(parser)
-    add_catalog_args(parser)
 
     parser.add_argument(
         "--pattern",
@@ -62,17 +59,10 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         print(f"Unable to load manifest file ({e})")
         return 1
 
-    try:
-        catalog = get_dbt_catalog(args)
-    except JsonOpenError as e:
-        print(f"Unable to load catalog file ({e})")
-        return 1
-
     start_time = time.time()
     status_code = check_model_name_contract(
         paths=args.filenames,
         pattern=args.pattern,
-        catalog=catalog,
         manifest=manifest,
         exclude_pattern=args.exclude,
         include_disabled=args.include_disabled,

--- a/tests/unit/test_check_model_name_contract.py
+++ b/tests/unit/test_check_model_name_contract.py
@@ -4,15 +4,14 @@ from dbt_checkpoint.check_model_name_contract import main
 
 # Input args, valid manifest, valid_config, expected return value
 TESTS = (
-    (["aa/bb/catalog_cols.sql", "--is_test"], "catalog_.*", True, True, True, 0),
-    (["aa/bb/catalog_cols.sql", "--is_test"], "catalog_.*", False, True, True, 1),
-    (["aa/bb/catalog_cols.sql", "--is_test"], "catalog_.*", True, False, True, 1),
-    (["aa/bb/catalog_cols.sql", "--is_test"], ".*_cols", True, True, True, 0),
-    (["aa/bb/catalog_cols.sql", "--is_test"], ".*_col", True, True, True, 0),
-    (["aa/bb/catalog_cols.sql", "--is_test"], ".*_col$", True, True, True, 1),
-    (["aa/bb/catalog_cols.sql", "--is_test"], "catalog_cols", True, True, True, 0),
-    (["aa/bb/catalog_cols.sql", "--is_test"], "cat_.*", True, True, True, 1),
-    (["aa/bb/catalog_cols.sql", "--is_test"], "catalog_.*", True, True, False, 0),
+    (["aa/bb/catalog_cols.sql", "--is_test"], "catalog_.*", True, True, 0),
+    (["aa/bb/catalog_cols.sql", "--is_test"], "catalog_.*", False, True, 1),
+    (["aa/bb/catalog_cols.sql", "--is_test"], ".*_cols", True, True, 0),
+    (["aa/bb/catalog_cols.sql", "--is_test"], ".*_col", True, True, 0),
+    (["aa/bb/catalog_cols.sql", "--is_test"], ".*_col$", True, True, 1),
+    (["aa/bb/catalog_cols.sql", "--is_test"], "catalog_cols", True, True, 0),
+    (["aa/bb/catalog_cols.sql", "--is_test"], "cat_.*", True, True, 1),
+    (["aa/bb/catalog_cols.sql", "--is_test"], "catalog_.*", True, False, 0),
 )
 
 
@@ -20,7 +19,6 @@ TESTS = (
     (
         "input_args",
         "pattern",
-        "valid_catalog",
         "valid_manifest",
         "valid_config",
         "expected_status_code",
@@ -30,22 +28,14 @@ TESTS = (
 def test_model_name_contract(
     input_args,
     pattern,
-    valid_catalog,
     valid_manifest,
     valid_config,
     expected_status_code,
     catalog_path_str,
     manifest_path_str,
-    config_path_str,
 ):
-    if valid_catalog:
-        input_args.extend(["--catalog", catalog_path_str])
-
     if valid_manifest:
         input_args.extend(["--manifest", manifest_path_str])
-
-    if valid_config:
-        input_args.extend(["--config", config_path_str])
 
     input_args.extend(["--pattern", pattern])
 


### PR DESCRIPTION
`check-model-name-contract` currently requires a populated `catalog.json` to be present. This is unfortunate because generating a `catalog.json` requires a connection to the underlying database, something not always possible from a CI pipeline. Why this is needed is unknown, because the same information is already present in `manifest.json`. This PR switches `check-model-name-contract` from using `catalog.json` to `manifest.json` so that this hook can be used without a database connection.