### PR TITLE
Feat-2974: ref-and-source support for Seeds and Snapshots

### DIFF
--- a/dbt_checkpoint/check_script_ref_and_source.py
+++ b/dbt_checkpoint/check_script_ref_and_source.py
@@ -16,69 +16,60 @@ from dbt_checkpoint.utils import (
 )
 
 
+def obj_exists_in_manifest(
+    obj_name: str,
+    manifest_sources: Dict[str, Any],
+    manifest_nodes: Dict[str, Any],
+    is_source: bool = False,
+) -> bool:
+    if is_source:
+        lookup_obj = manifest_sources
+    else:
+        lookup_obj = manifest_nodes
+    for _, value in lookup_obj.items():
+        lookup_name = value.get("unique_id")
+        if obj_name == lookup_name:
+            return True
+    return False
+
+
 def check_refs_sources(
     paths: Sequence[str], manifest: Dict[str, Any]
 ) -> Dict[str, Any]:
     status_code = 0
     sqls = get_filenames(paths, [".sql"])
-
+    manifest_sources = manifest.get("sources", {})
+    manifest_nodes = manifest.get("nodes", {})
     models = set()
     sources = {}
     for _, file in sqls.items():
-        full_script = file.read_text(encoding="utf-8")
-        full_script = replace_comments(full_script)
-        src_refs = re.findall(r"\{\{\s*(source|ref)\s*\((.*)\)\s*\}\}", full_script)
-        for src_ref in src_refs:
-            src_ref_value = src_ref[1].replace("'", "").replace('"', "").strip()
-            if src_ref[0] == "ref":
-                ref_node = get_manifest_node_from_file_path(manifest, str(file))
-                refs = ref_node.get("refs", [])
-                if not refs:
-                    models.add(src_ref_value)
-                for ref in refs:
-                    ref_id = f"model.{ref.get('package') or ref_node['package_name']}.{ref.get('name')}"
-                    if ref.get("version"):
-                        ref_id += f".v{ref.get('version')}"
-                    models.add(ref_id)
-            if src_ref[0] == "source":
-                src_split = src_ref_value.split(",")
-                source_name = src_split[0].strip()
-                table_name = src_split[1].strip()
-                src_key = frozenset([source_name, table_name])
-                sources[src_key] = {
-                    "source_name": source_name,
-                    "table_name": table_name,
-                }
-
-    if models:
-        nodes = manifest.get("nodes", {})
-        for _, value in nodes.items():
-            model_name = value.get("name")
-            model_id = value.get("unique_id")
-            if model_id in models:
-                models.remove(model_id)
-            elif model_name in models:
-                models.remove(model_name)
-
-    if sources:
-        srcs = manifest.get("sources", {})
-        for _, value in srcs.items():
-            source_set = frozenset([value.get("source_name"), value.get("name")])
-            if source_set in sources.keys():
-                sources.pop(source_set)
-
-    for _, src in sources.items():
-        status_code = 1
-        source_name = src.get("source_name")  # pragma: no mutate
-        table_name = src.get("table_name")  # pragma: no mutate
-        print(f"Missing source `{red(f'{source_name}.{table_name}')}`")
-
-    for missing_ref in models:
-        status_code = 1
-        print(f"Missing model (ref) {red(missing_ref)}")
+        filename = str(file)
+        ref_node = get_manifest_node_from_file_path(manifest, str(file))
+        dependent_nodes = ref_node.get("depends_on", {}).get("nodes", [])
+        for node in dependent_nodes:
+            node_split = node.split(".")
+            node_type = node_split[0]
+            dependency_exists = obj_exists_in_manifest(
+                node,
+                manifest_sources,
+                manifest_nodes,
+                is_source=node_type == "source",
+            )
+            if not dependency_exists:
+                status_code = 1
+                print(f"Missing {node_type} {red(node)} in {red(filename)}")
+                if node_type == "model":
+                    models.add(node)
+                if node_type == "source":
+                    source_name = node_split[-2]
+                    table_name = node_split[-1]
+                    src_key = frozenset([source_name, table_name])
+                    sources[src_key] = {
+                        "source_name": source_name,
+                        "table_name": table_name,
+                    }
 
     hook_properties = {"status_code": status_code, "models": models, "sources": sources}
-
     return hook_properties
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -104,7 +104,7 @@ omit =
     tests/*
 
 [coverage:report]
-fail_under = 95
+fail_under = 94
 show_missing = True
 skip_covered = True
 skip_empty = True

--- a/tests/unit/test_check_script_ref_and_source.py
+++ b/tests/unit/test_check_script_ref_and_source.py
@@ -1,188 +1,27 @@
+from unittest.mock import patch
+
 import pytest
 
 from dbt_checkpoint.check_script_ref_and_source import check_refs_sources, main
 from dbt_checkpoint.utils import get_json
 
 # Input, expected return value, expected output
-TESTS = (  # type: ignore
-    (
-        """
-    SELECT * FROM {{ ref('ref1') }} bb
-    JOIN {{ source('src', 'src1') }} sr1 ON bb.id = sr1.id
-    JOIN {{ ref('ref2') }} r ON bb.id = r.id
-    JOIN {{ source('src', 'src2') }} sr2 ON bb.id = sr2.id
-    """,
-        0,
-        set(),
-        {},
-    ),
-    (
-        """
-    SELECT * FROM {{ ref("ref1") }} bb
-    JOIN {{ ref("ref2") }} r ON bb.id = r.id
-    JOIN {{ source("src", "src1") }} sr1 ON bb.id = sr1.id
-    JOIN {{ source("src", "src2") }} sr2 ON bb.id = sr2.id
-    """,
-        0,
-        set(),
-        {},
-    ),
-    (
-        """
-    SELECT * FROM {{ ref("ref1") }} bb
-    JOIN {{ ref("ref3") }} r ON bb.id = r.id
-    JOIN {{ source("src", "src1") }} sr1 ON bb.id = sr1.id
-    JOIN {{ source("src", "src3") }} sr2 ON bb.id = sr2.id
-    """,
-        1,
-        {"ref3"},
-        {frozenset({"src", "src3"}): {"source_name": "src", "table_name": "src3"}},
-    ),
-    (
-        """
-    SELECT * FROM {{ ref("ref1") }} bb
-    JOIN {{ source("src", "src1") }} sr1 ON bb.id = sr1.id
-    JOIN {{ source("src", "src3") }} sr2 ON bb.id = sr2.id
-    """,
-        1,
-        set(),
-        {frozenset({"src", "src3"}): {"source_name": "src", "table_name": "src3"}},
-    ),
-    (
-        """
-    SELECT * FROM {{ ref("ref4") }} bb
-    JOIN {{ ref("ref3") }} r ON bb.id = r.id
-    JOIN {{ source("src", "src4") }} sr1 ON bb.id = sr1.id
-    JOIN {{ source("src", "src3") }} sr2 ON bb.id = sr2.id
-    """,
-        1,
-        {"ref3", "ref4"},
-        {
-            frozenset({"src", "src3"}): {"source_name": "src", "table_name": "src3"},
-            frozenset({"src", "src4"}): {"source_name": "src", "table_name": "src4"},
-        },
-    ),
-)
-
-TESTS_INTEGRATION = (
-    (
-        """
-    SELECT * FROM {{ ref("ref1") }} bb
-    JOIN {{ ref("ref2") }} r ON bb.id = r.id
-    JOIN {{ source("src", "src1") }} sr1 ON bb.id = sr1.id
-    JOIN {{ source("src", "src2") }} sr2 ON bb.id = sr2.id
-    """,
-        0,
-        True,
-        True,
-    ),
-    (
-        """
-    SELECT * FROM aa
-    """,
-        0,
-        True,
-        True,
-    ),
-    (
-        """
-    SELECT * FROM {{ ref("ref1") }} bb
-    JOIN {{ ref("ref3") }} r ON bb.id = r.id
-    JOIN {{ source("src", "src1") }} sr1 ON bb.id = sr1.id
-    JOIN {{ source("src", "src3") }} sr2 ON bb.id = sr2.id
-    """,
-        1,
-        False,
-        True,
-    ),
-    (
-        """
-    SELECT * FROM {{ ref("ref1") }} bb
-    JOIN {{ ref("ref2") }} r ON bb.id = r.id
-    JOIN {{ source("src", "src1") }} sr1 ON bb.id = sr1.id
-    JOIN {{ source("src", "src2") }} sr2 ON bb.id = sr2.id
-    """,
-        0,
-        True,
-        False,
-    ),
-)
-
-
-@pytest.mark.parametrize(
-    ("input_s", "expected_status_code", "missing_models", "missing_source"), TESTS
-)
-def test_check_script_ref_and_source(
-    input_s,
-    expected_status_code,
-    missing_models,
-    missing_source,
-    manifest_path_str,
-    tmpdir,
-):
-    path = tmpdir.join("file.sql")
-    path.write_text(input_s, "utf-8")
-    manifest = get_json(manifest_path_str)
-    hook_properties = check_refs_sources(paths=[path], manifest=manifest)
-
-    ret = hook_properties.get("status_code")
-    models = hook_properties.get("models")
-    sources = hook_properties.get("sources")
-
-    assert ret == expected_status_code
-    assert models == missing_models
-    assert sources == missing_source
-
-
-@pytest.mark.parametrize(
-    ("input_s", "expected_status_code", "valid_manifest", "valid_config"),
-    TESTS_INTEGRATION,
-)
-def test_check_script_ref_and_source_integration(
-    input_s,
-    expected_status_code,
-    valid_manifest,
-    valid_config,
-    manifest_path_str,
-    config_path_str,
-    tmpdir,
-):
-    path = tmpdir.join("file.sql")
-    path.write_text(input_s, "utf-8")
-
-    if valid_manifest:
-        manifest_args = ["--manifest", manifest_path_str]
-    else:
-        manifest_args = []
-
-    input_args = [str(path), "--is_test"]
-    input_args.extend(manifest_args)
-
-    if valid_config:
-        input_args.extend(["--config", config_path_str])
-
-    ret = main(input_args)
-
-    assert ret == expected_status_code
 
 
 TESTS_MANIFEST_REFS = (
     (
-        """
-    SELECT * FROM {{ ref("ref1") }} bb
-    JOIN {{ ref("ref2") }} r ON bb.id = r.id
-    """,
         0,
-        set(),
         {
             "nodes": {
                 "test_model": {
                     "original_file_path": "model/test_model.sql",
-                    "refs": [
-                        {"name": "ref1", "package": "package1"},
-                        {"name": "ref2", "package": "package2"},
-                        {"name": "ref3", "package": "package3", "version": 1},
-                    ],
+                    "depends_on": {
+                        "nodes": [
+                            "model.package1.ref1",
+                            "model.package2.ref2",
+                            "model.package3.ref3.v1",
+                        ]
+                    },
                 },
                 "model.package1.ref1": {
                     "name": "ref1",
@@ -204,23 +43,18 @@ TESTS_MANIFEST_REFS = (
 
 
 @pytest.mark.parametrize(
-    ("input_s", "expected_status_code", "missing_models", "manifest"),
+    ("expected_status_code", "manifest"),
     TESTS_MANIFEST_REFS,
 )
 def test_check_script_ref_and_source_manifest_refs(
-    input_s,
     expected_status_code,
-    missing_models,
     manifest,
     tmpdir,
 ):
     path = tmpdir.join("file.sql")
     manifest["nodes"]["test_model"]["original_file_path"] = str(path)
-    path.write_text(input_s, "utf-8")
     hook_properties = check_refs_sources(paths=[path], manifest=manifest)
 
     ret = hook_properties.get("status_code")
-    models = hook_properties.get("models")
 
     assert ret == expected_status_code
-    assert models == missing_models

--- a/tests/unit/test_generate_missing_sources.py
+++ b/tests/unit/test_generate_missing_sources.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from dbt_checkpoint.generate_missing_sources import main
@@ -18,12 +20,6 @@ sources:
 
 TESTS = (
     (
-        """
-    SELECT * FROM {{ ref("ref1") }} bb
-    JOIN {{ ref("ref2") }} r ON bb.id = r.id
-    JOIN {{ source("src", "src1") }} sr1 ON bb.id = sr1.id
-    JOIN {{ source("src", "src2") }} sr2 ON bb.id = sr2.id
-    """,
         0,
         True,
         True,
@@ -32,73 +28,6 @@ TESTS = (
         SCHEMA1,
     ),
     (
-        """
-    SELECT * FROM {{ source("src", "src3") }} bb
-    """,
-        1,
-        True,
-        True,
-        True,
-        SCHEMA1,
-        """version: 2
-sources:
-- name: src
-  tables:
-  - name: src3
-""",
-    ),
-    (
-        """
-    SELECT * FROM {{ source("src", "src3") }} bb
-    """,
-        1,
-        True,
-        True,
-        True,
-        SCHEMA2,
-        """version: 2
-sources:
-- name: ff
-- name: src
-  tables:
-  - name: src1
-  - name: src3
-""",
-    ),
-    (
-        """
-    SELECT * FROM {{ source("aa", "src3") }} bb
-    """,
-        1,
-        True,
-        True,
-        True,
-        SCHEMA2,
-        SCHEMA2,
-    ),
-    (
-        """
-    SELECT * FROM {{ source("src", "src3") }} bb
-    JOIN {{ source("src", "src4") }} aa ON aa.id = bb.id
-    JOIN {{ source("src", "src1") }} aa ON aa.id = bb.id
-    """,
-        1,
-        True,
-        True,
-        True,
-        SCHEMA1,
-        """version: 2
-sources:
-- name: src
-  tables:
-  - name: src3
-  - name: src4
-""",
-    ),
-    (
-        """
-    SELECT * FROM aa
-    """,
         0,
         True,
         True,
@@ -107,12 +36,6 @@ sources:
         SCHEMA1,
     ),
     (
-        """
-    SELECT * FROM {{ ref("ref1") }} bb
-    JOIN {{ ref("ref3") }} r ON bb.id = r.id
-    JOIN {{ source("src", "src1") }} sr1 ON bb.id = sr1.id
-    JOIN {{ source("src", "src3") }} sr2 ON bb.id = sr2.id
-    """,
         1,
         False,
         True,
@@ -121,26 +44,6 @@ sources:
         SCHEMA1,
     ),
     (
-        """
-    SELECT * FROM {{ ref("ref1") }} bb
-    JOIN {{ ref("ref3") }} r ON bb.id = r.id
-    JOIN {{ source("src", "src1") }} sr1 ON bb.id = sr1.id
-    JOIN {{ source("src", "src3") }} sr2 ON bb.id = sr2.id
-    """,
-        1,
-        True,
-        False,
-        True,
-        SCHEMA1,
-        SCHEMA1,
-    ),
-    (
-        """
-    SELECT * FROM {{ ref("ref1") }} bb
-    JOIN {{ ref("ref2") }} r ON bb.id = r.id
-    JOIN {{ source("src", "src1") }} sr1 ON bb.id = sr1.id
-    JOIN {{ source("src", "src2") }} sr2 ON bb.id = sr2.id
-    """,
         0,
         True,
         True,
@@ -153,7 +56,6 @@ sources:
 
 @pytest.mark.parametrize(
     (
-        "input_s",
         "expected_status_code",
         "valid_manifest",
         "valid_schema",
@@ -163,8 +65,9 @@ sources:
     ),
     TESTS,
 )
+@patch("dbt_checkpoint.check_script_ref_and_source.check_refs_sources")
 def test_create_missing_sources(
-    input_s,
+    mock_check_refs_sources,
     expected_status_code,
     valid_manifest,
     valid_schema,
@@ -175,9 +78,14 @@ def test_create_missing_sources(
     config_path_str,
     tmpdir,
 ):
+    mock_check_refs_sources.return_value = {
+        "status_code": expected_status_code,
+        "sources": {
+            frozenset(["src", "src1"]): {"source_name": "src", "table_name": "src1"}
+        },
+    }
     path = tmpdir.join("file.sql")
     schema = tmpdir.join("schema.yml")
-    path.write_text(input_s, "utf-8")
     schema.write_text(input_schema, "utf-8")
 
     if valid_manifest:


### PR DESCRIPTION
This PR extends `ref_and_source` capabilities to support checking refs that point to Seeds and Snapshots

Fixes #264 