### PR TITLE
Fix check_model_has_description missing-filepath sql detection

### DIFF
--- a/dbt_checkpoint/check_model_has_description.py
+++ b/dbt_checkpoint/check_model_has_description.py
@@ -24,7 +24,7 @@ def has_description(
     include_disabled: bool = False,
 ) -> Dict[str, Any]:
     paths = get_missing_file_paths(  # type: ignore
-        paths, manifest, extensions=[".yml", ".yaml"], exclude_pattern=exclude_pattern
+        paths, manifest, exclude_pattern=exclude_pattern
     )
 
     status_code = 0


### PR DESCRIPTION
This PR fixes a situation where, submitting YML files only, Model SQLs were not taken into account