### PR TITLE
remove dbt cloud sentence in Ci/CD section

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,6 @@ repos:
 
 ## Run in CI/CD
 
-Unfortunately, you cannot natively use `dbt-checkpoint` if you are using **dbt Cloud**. But you can run checks after you push changes into Github.
-
 `dbt-checkpoint` for the most of the hooks needs `manifest.json` (see requirements section in hook documentation), that is in the `target` folder. Since this target folder is usually in `.gitignore`, you need to generate it. For that you need to run the `dbt-parse` command.
 To be able to parse dbt, you also need [profiles.yml](https://docs.getdbt.com/dbt-cli/configure-your-profile) file with your credentials. **To provide passwords and secrets use Github Secrets** (see example).
 


### PR DESCRIPTION
It's possible to use dbt-checkpoint as part of CI / CD if you're using dbt Cloud.

Here's an example [workflow](https://github.com/dpguthrie/snowflake-dbt-demo-new/blob/main/.github/workflows/pre_commit.yml) and a [run](https://github.com/dpguthrie/snowflake-dbt-demo-new/actions/runs/11919336633/job/33218820694) where it checked if a file had a hardcoded table name.

More than happy to provide more examples if it would be helpful.