### PR TITLE
fix: Perform a final filter to only file paths in the output

### DIFF
--- a/dbt_checkpoint/utils.py
+++ b/dbt_checkpoint/utils.py
@@ -1,10 +1,12 @@
 import argparse
 import json
+import os
 import re
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Generator, List, Optional, Sequence, Set, Text, Union
+
 
 from yaml import safe_load
 
@@ -770,7 +772,8 @@ def get_missing_file_paths(
             for filename in paths_with_missing
             if not exclude_re.search(filename)
         ]
-    return paths_with_missing
+    file_paths_with_missing = [p for p in paths_with_missing if not os.path.isdir(p)]
+    return file_paths_with_missing
 
 
 def red(string: Optional[Any]) -> str:


### PR DESCRIPTION
Related issue: https://github.com/dbt-checkpoint/dbt-checkpoint/issues/221

I'm not sure if this is the ideal way to fix this issue but it seems reasonable. In our use case the problem occurs in the same context as described in the issue
> the target directory YAML file actually is a directory that contains the SQL for the tests defined in the project directory YAML file.

Verifying that the files retrieved by `get_missing_file_paths` are actually files should resolve that. 
I'm not aware whether this would break some other behavior which depends on `get_missing_file_paths` response including directories, but based on the name of the function it seemed reasonable to expect that the intention is that it returns file paths.