### PR TITLE
fix: update check_column_name_contract to work with versioned models …

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -192,7 +192,7 @@ You want to make sure your columns follow a contract, e.g. all your boolean colu
 
 | Model exists in `manifest.json` <sup id="a1">[1](#f1)</sup> | Model exists in `catalog.json` <sup id="a2">[2](#f2)</sup> |
 | :---------------------------------------------------------: | :--------------------------------------------------------: |
-|                       :x: Not needed                        |                   :white_check_mark: Yes                   |
+|                   :white_check_mark: Yes                    |                   :white_check_mark: Yes                   |
 
 <sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
 <sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -347,6 +347,33 @@ MANIFEST = {
                 "materialized": "snapshot",
             },
         },
+        "model.test.with_boolean_column_with_prefix": {
+            "name": "with_boolean_column_with_prefix",
+            "patch_path": "project://bb/with_boolean_column_with_prefix.yml",
+            "path": "aa/bb/with_boolean_column_with_prefix.sql",
+        },
+        "model.test.with_boolean_column_with_prefix_version.v1": {
+            "name": "with_boolean_column_with_prefix_version",
+            "patch_path": "project://bb/with_boolean_column_with_prefix_version.yml",
+            "path": "aa/bb/with_boolean_column_with_prefix_version_v1.sql",
+            "version": 1,
+            "latest_version": 1,
+        },
+        "model.test.with_boolean_column_without_prefix": {
+            "name": "with_boolean_column_without_prefix",
+            "patch_path": "project://bb/with_boolean_column_without_prefix.yml",
+            "path": "aa/bb/with_boolean_column_without_prefix.sql",
+        },
+        "model.test.without_boolean_column_with_prefix": {
+            "name": "without_boolean_column_with_prefix",
+            "patch_path": "project://bb/without_boolean_column_with_prefix.yml",
+            "path": "aa/bb/without_boolean_column_with_prefix.sql",
+        },
+        "model.test.without_boolean_column_without_prefix": {
+            "name": "without_boolean_column_without_prefix",
+            "patch_path": "project://bb/without_boolean_column_without_prefix.yml",
+            "path": "aa/bb/without_boolean_column_without_prefix.sql",
+        },
     },
     "sources": {
         "source.source1.table1": {
@@ -474,6 +501,14 @@ CATALOG = {
         },
         "model.test.only_model_cols": {"metadata": {}, "columns": {}},
         "model.test.with_boolean_column_with_prefix": {
+            "metadata": {},
+            "columns": {
+                "is_boolean": {"type": "boolean", "name": "is_boolean"},
+                "COL2": {"type": "TEXT", "name": "COL2"},
+                "IS_ALSO_BOOLEAN": {"type": "BOOLEAN", "name": "IS_ALSO_BOOLEAN"},
+            },
+        },
+        "model.test.with_boolean_column_with_prefix_version.v1": {
             "metadata": {},
             "columns": {
                 "is_boolean": {"type": "boolean", "name": "is_boolean"},

--- a/tests/unit/test_check_column_name_contract.py
+++ b/tests/unit/test_check_column_name_contract.py
@@ -14,6 +14,15 @@ TESTS = (
         0,
     ),
     (
+        ["aa/bb/with_boolean_column_with_prefix_version_v1.sql", "is_test"],
+        "is_.*",
+        "boolean",
+        True,
+        True,
+        True,
+        0,
+    ),
+    (
         ["aa/bb/with_boolean_column_with_prefix.sql", "is_test"],
         "is_.*",
         "boolean",


### PR DESCRIPTION
- Updates `dbt_checkpoint/check_column_name_contract.py` to utilize both the manifest and catalog. This allows it to work correctly with the `get_models` function.
- Updated the related tests and tests config including add a versioned model.

Description of the issue can be found in #203.